### PR TITLE
fix: visual QA fixes, panel preservation, and code simplification

### DIFF
--- a/catalog/src/utils/noop-context.ts
+++ b/catalog/src/utils/noop-context.ts
@@ -143,6 +143,7 @@ export function createNoopSimrelContext(): SimRelUISpecRenderContext {
       emptyStateMessage: 'No similar products found.',
       addToCartButton: 'Add to Cart',
       ctaLabel: 'View',
+      outOfStockLabel: 'Out of Stock',
       priceSuffix: ' TL',
     },
     pricing: {

--- a/src/chat/components/AITopPicks.ts
+++ b/src/chat/components/AITopPicks.ts
@@ -137,12 +137,19 @@ function renderTopPickCard(item: AITopPickItem, ctx: ChatUISpecRenderContext): H
     body.appendChild(renderSentimentChips(item.labels));
   }
 
-  // Expert quality score — auto-detect scale from value range
+  // Expert quality score — normalize to 0-10 scale
   if (typeof item.expertQualityScore === 'number') {
     const score = document.createElement('div');
     score.className = 'gengage-chat-ai-toppick-score';
-    const maxScale = item.expertQualityScore <= 5 ? 5 : 10;
-    score.textContent = `${item.expertQualityScore}/${maxScale}`;
+    let displayScore = item.expertQualityScore;
+    let maxScale = 10;
+    if (displayScore > 10) {
+      // Percentage-style score (e.g. 92) → normalize to x/10
+      displayScore = Math.round(displayScore) / 10;
+    } else if (displayScore <= 5) {
+      maxScale = 5;
+    }
+    score.textContent = `${displayScore}/${maxScale}`;
     body.appendChild(score);
   }
 

--- a/src/chat/components/CategoriesContainer.ts
+++ b/src/chat/components/CategoriesContainer.ts
@@ -12,6 +12,8 @@ import type { UIElement } from '../../common/types.js';
 import type { ChatUISpecRenderContext } from '../types.js';
 import type { NormalizedProduct } from '../../common/protocol-adapter.js';
 import { isSafeImageUrl } from '../../common/safe-html.js';
+import { formatPrice } from '../../common/price-formatter.js';
+import { addImageErrorHandler } from '../../common/product-utils.js';
 
 interface GroupData {
   groupName: string;
@@ -141,6 +143,8 @@ function renderCategoryProductCard(product: NormalizedProduct, ctx: ChatUISpecRe
     img.className = 'gengage-chat-product-card-img';
     img.src = product.imageUrl;
     img.alt = product.name;
+    img.loading = 'lazy';
+    addImageErrorHandler(img);
     card.appendChild(img);
   }
 
@@ -155,7 +159,7 @@ function renderCategoryProductCard(product: NormalizedProduct, ctx: ChatUISpecRe
   if (product.price) {
     const priceEl = document.createElement('div');
     priceEl.className = 'gengage-chat-product-card-price';
-    priceEl.textContent = product.price;
+    priceEl.textContent = formatPrice(product.price, ctx.pricing);
     body.appendChild(priceEl);
   }
 

--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -202,65 +202,60 @@ export class ChatDrawer {
       let swipeDeltaY = 0;
       const DISMISS_THRESHOLD = 80;
 
-      header.addEventListener(
-        'touchstart',
-        (e) => {
-          // Only on mobile-sized viewports
-          if (window.innerWidth > 768) return;
-          const t = e.changedTouches?.[0];
-          if (!t) return;
-          swipeStartY = t.clientY;
-          swipeDeltaY = 0;
-          // Disable transition during drag for immediate visual feedback
-          this.root.style.transition = 'none';
-        },
-        { passive: true },
-      );
+      const onHeaderTouchStart = (e: TouchEvent) => {
+        // Only on mobile-sized viewports
+        if (window.innerWidth > 768) return;
+        const t = e.changedTouches?.[0];
+        if (!t) return;
+        swipeStartY = t.clientY;
+        swipeDeltaY = 0;
+        // Disable transition during drag for immediate visual feedback
+        this.root.style.transition = 'none';
+      };
 
-      header.addEventListener(
-        'touchmove',
-        (e) => {
-          if (swipeStartY === null) return;
-          const t = e.changedTouches?.[0];
-          if (!t) return;
-          swipeDeltaY = Math.max(0, t.clientY - swipeStartY); // Only allow downward drag
-          this.root.style.transform = `translateY(${swipeDeltaY}px)`;
-          this.root.style.opacity = String(1 - swipeDeltaY / 300);
-        },
-        { passive: true },
-      );
+      const onHeaderTouchMove = (e: TouchEvent) => {
+        if (swipeStartY === null) return;
+        const t = e.changedTouches?.[0];
+        if (!t) return;
+        swipeDeltaY = Math.max(0, t.clientY - swipeStartY); // Only allow downward drag
+        this.root.style.transform = `translateY(${swipeDeltaY}px)`;
+        this.root.style.opacity = String(1 - swipeDeltaY / 300);
+      };
 
-      header.addEventListener(
-        'touchend',
-        () => {
-          if (swipeStartY === null) return;
-          swipeStartY = null;
-          // Re-enable transition
-          this.root.style.transition = '';
-          if (swipeDeltaY >= DISMISS_THRESHOLD) {
-            // Dismiss — let the CSS transition handle the animation
-            options.onClose();
-          }
-          // Reset transform
-          this.root.style.transform = '';
-          this.root.style.opacity = '';
-          swipeDeltaY = 0;
-        },
-        { passive: true },
-      );
+      const onHeaderTouchEnd = () => {
+        if (swipeStartY === null) return;
+        swipeStartY = null;
+        // Re-enable transition
+        this.root.style.transition = '';
+        if (swipeDeltaY >= DISMISS_THRESHOLD) {
+          // Dismiss — let the CSS transition handle the animation
+          options.onClose();
+        }
+        // Reset transform
+        this.root.style.transform = '';
+        this.root.style.opacity = '';
+        swipeDeltaY = 0;
+      };
 
-      header.addEventListener(
-        'touchcancel',
-        () => {
-          if (swipeStartY === null) return;
-          swipeStartY = null;
-          this.root.style.transition = '';
-          this.root.style.transform = '';
-          this.root.style.opacity = '';
-          swipeDeltaY = 0;
-        },
-        { passive: true },
-      );
+      const onHeaderTouchCancel = () => {
+        if (swipeStartY === null) return;
+        swipeStartY = null;
+        this.root.style.transition = '';
+        this.root.style.transform = '';
+        this.root.style.opacity = '';
+        swipeDeltaY = 0;
+      };
+
+      header.addEventListener('touchstart', onHeaderTouchStart, { passive: true });
+      header.addEventListener('touchmove', onHeaderTouchMove, { passive: true });
+      header.addEventListener('touchend', onHeaderTouchEnd, { passive: true });
+      header.addEventListener('touchcancel', onHeaderTouchCancel, { passive: true });
+      this._cleanups.push(() => {
+        header.removeEventListener('touchstart', onHeaderTouchStart);
+        header.removeEventListener('touchmove', onHeaderTouchMove);
+        header.removeEventListener('touchend', onHeaderTouchEnd);
+        header.removeEventListener('touchcancel', onHeaderTouchCancel);
+      });
     }
 
     // Body: flex container for panel + conversation
@@ -303,41 +298,39 @@ export class ChatDrawer {
     let touchStartX: number | null = null;
     let touchStartY: number | null = null;
     const swipeThreshold = 24;
-    this._dividerEl.addEventListener(
-      'touchstart',
-      (event) => {
-        if (window.innerWidth > 768) return;
-        const touch = event.changedTouches?.[0];
-        if (!touch) return;
-        touchStartX = touch.clientX;
-        touchStartY = touch.clientY;
-      },
-      { passive: true },
-    );
-    this._dividerEl.addEventListener(
-      'touchend',
-      (event) => {
-        if (window.innerWidth > 768) return;
-        if (touchStartX === null || touchStartY === null) return;
-        const touch = event.changedTouches?.[0];
-        if (!touch) return;
+    const onDividerTouchStart = (event: TouchEvent) => {
+      if (window.innerWidth > 768) return;
+      const touch = event.changedTouches?.[0];
+      if (!touch) return;
+      touchStartX = touch.clientX;
+      touchStartY = touch.clientY;
+    };
+    const onDividerTouchEnd = (event: TouchEvent) => {
+      if (window.innerWidth > 768) return;
+      if (touchStartX === null || touchStartY === null) return;
+      const touch = event.changedTouches?.[0];
+      if (!touch) return;
 
-        const deltaX = touch.clientX - touchStartX;
-        const deltaY = touch.clientY - touchStartY;
-        touchStartX = null;
-        touchStartY = null;
+      const deltaX = touch.clientX - touchStartX;
+      const deltaY = touch.clientY - touchStartY;
+      touchStartX = null;
+      touchStartY = null;
 
-        // Vertical swipe only. Swipe up collapses panel, swipe down expands.
-        if (Math.abs(deltaY) < swipeThreshold || Math.abs(deltaY) < Math.abs(deltaX)) return;
-        const nextCollapsed = deltaY < 0;
-        if (nextCollapsed === this._panelCollapsed) return;
+      // Vertical swipe only. Swipe up collapses panel, swipe down expands.
+      if (Math.abs(deltaY) < swipeThreshold || Math.abs(deltaY) < Math.abs(deltaX)) return;
+      const nextCollapsed = deltaY < 0;
+      if (nextCollapsed === this._panelCollapsed) return;
 
-        this._ignoreNextDividerClick = true;
-        this.setPanelCollapsed(nextCollapsed);
-        this._onPanelToggle?.();
-      },
-      { passive: true },
-    );
+      this._ignoreNextDividerClick = true;
+      this.setPanelCollapsed(nextCollapsed);
+      this._onPanelToggle?.();
+    };
+    this._dividerEl.addEventListener('touchstart', onDividerTouchStart, { passive: true });
+    this._dividerEl.addEventListener('touchend', onDividerTouchEnd, { passive: true });
+    this._cleanups.push(() => {
+      this._dividerEl.removeEventListener('touchstart', onDividerTouchStart);
+      this._dividerEl.removeEventListener('touchend', onDividerTouchEnd);
+    });
     this._dividerEl.appendChild(chevron);
     body.appendChild(this._dividerEl);
 
@@ -380,19 +373,19 @@ export class ChatDrawer {
 
     // Track user scroll position to avoid auto-scrolling when reading history
     let scrollRafPending = false;
-    this.messagesEl.addEventListener(
-      'scroll',
-      () => {
-        if (scrollRafPending) return;
-        scrollRafPending = true;
-        requestAnimationFrame(() => {
-          scrollRafPending = false;
-          const { scrollTop, scrollHeight, clientHeight } = this.messagesEl;
-          this._userScrolledUp = scrollHeight - scrollTop - clientHeight > 10;
-        });
-      },
-      { passive: true },
-    );
+    const onMessagesScroll = () => {
+      if (scrollRafPending) return;
+      scrollRafPending = true;
+      requestAnimationFrame(() => {
+        scrollRafPending = false;
+        const { scrollTop, scrollHeight, clientHeight } = this.messagesEl;
+        this._userScrolledUp = scrollHeight - scrollTop - clientHeight > 10;
+      });
+    };
+    this.messagesEl.addEventListener('scroll', onMessagesScroll, { passive: true });
+    this._cleanups.push(() => {
+      this.messagesEl.removeEventListener('scroll', onMessagesScroll);
+    });
 
     conversation.appendChild(this.messagesEl);
 
@@ -425,19 +418,19 @@ export class ChatDrawer {
 
     // Hide arrow when fully scrolled
     let pillsRafPending = false;
-    pillsScroll.addEventListener(
-      'scroll',
-      () => {
-        if (pillsRafPending) return;
-        pillsRafPending = true;
-        requestAnimationFrame(() => {
-          pillsRafPending = false;
-          const atEnd = pillsScroll.scrollLeft + pillsScroll.clientWidth >= pillsScroll.scrollWidth - 4;
-          pillsArrow.style.display = atEnd ? 'none' : '';
-        });
-      },
-      { passive: true },
-    );
+    const onPillsScroll = () => {
+      if (pillsRafPending) return;
+      pillsRafPending = true;
+      requestAnimationFrame(() => {
+        pillsRafPending = false;
+        const atEnd = pillsScroll.scrollLeft + pillsScroll.clientWidth >= pillsScroll.scrollWidth - 4;
+        pillsArrow.style.display = atEnd ? 'none' : '';
+      });
+    };
+    pillsScroll.addEventListener('scroll', onPillsScroll, { passive: true });
+    this._cleanups.push(() => {
+      pillsScroll.removeEventListener('scroll', onPillsScroll);
+    });
 
     conversation.appendChild(this._pillsEl);
 

--- a/src/chat/components/ProductSummaryCard.ts
+++ b/src/chat/components/ProductSummaryCard.ts
@@ -12,7 +12,7 @@ import type { UIElement } from '../../common/types.js';
 import type { ChatUISpecRenderContext } from '../types.js';
 import { formatPrice } from '../../common/price-formatter.js';
 import { isSafeUrl, safeSetAttribute } from '../../common/safe-html.js';
-import { clampRating, addImageErrorHandler, renderStarRating } from '../../common/product-utils.js';
+import { addImageErrorHandler, createStarRatingElement } from '../../common/product-utils.js';
 
 export function renderProductSummaryCard(element: UIElement, ctx: ChatUISpecRenderContext): HTMLElement {
   const product = (element.props?.['product'] ?? element.props) as Record<string, unknown> | undefined;
@@ -65,7 +65,7 @@ export function renderProductSummaryCard(element: UIElement, ctx: ChatUISpecRend
   if (typeof rating === 'number' && Number.isFinite(rating) && rating > 0) {
     const ratingRow = document.createElement('div');
     ratingRow.className = 'gengage-chat-product-summary__rating';
-    ratingRow.textContent = renderStarRating(clampRating(rating));
+    ratingRow.appendChild(createStarRatingElement(rating));
     if (typeof reviewCount === 'number' && Number.isFinite(reviewCount)) {
       const count = document.createElement('span');
       count.className = 'gengage-chat-product-summary__review-count';

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -984,6 +984,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
+  flex-shrink: 0;
   gap: 0;
   padding: 8px 12px;
   border-top: 1px solid var(--_gengage-border-color);
@@ -1138,15 +1139,9 @@
 
 .gengage-chat-action-buttons {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   padding: 6px 0 4px;
-  overflow-x: auto;
-  scrollbar-width: none;
-  -webkit-overflow-scrolling: touch;
-}
-
-.gengage-chat-action-buttons::-webkit-scrollbar {
-  display: none;
 }
 
 .gengage-chat-action-btn {
@@ -1177,6 +1172,8 @@
 
 .gengage-chat-product-card {
   position: relative;
+  display: flex;
+  flex-direction: column;
   border: 1px solid #eee;
   border-radius: 16px;
   overflow: hidden;
@@ -1208,6 +1205,7 @@
 .gengage-chat-product-card-body {
   display: flex;
   flex-direction: column;
+  flex: 1;
   gap: 4px;
   padding: 8px 10px 10px;
   text-align: center;
@@ -1219,7 +1217,7 @@
   color: var(--_gengage-text-primary);
   line-height: 1.35;
   margin-bottom: 0;
-  min-height: 0;
+  min-height: calc(2 * 1.35em);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   line-clamp: 2;
@@ -1239,6 +1237,19 @@
   line-height: 1;
 }
 
+.gengage-star-half {
+  display: inline-block;
+  position: relative;
+}
+
+.gengage-star-half > span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  overflow: hidden;
+  width: 0.5em;
+}
+
 .gengage-chat-product-card-review-count {
   color: #475569;
   font-size: 10px;
@@ -1246,9 +1257,10 @@
 
 .gengage-chat-product-card-price {
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   justify-content: center;
-  gap: 4px;
+  gap: 2px 4px;
   font-size: 16px;
   font-weight: 800;
   color: #0f172a;
@@ -1284,6 +1296,7 @@
 
 .gengage-chat-product-card-cta {
   display: block;
+  margin-top: auto;
   padding: 8px 10px;
   text-align: center;
   background: transparent;
@@ -2849,7 +2862,7 @@
 .gengage-chat-ai-toppick-discount-badge {
   position: absolute;
   top: 8px;
-  left: 8px;
+  right: 8px;
   background: var(--gengage-discount-bg, #ef4444);
   color: #fff;
   font-size: 11px;
@@ -3708,7 +3721,7 @@
   position: absolute;
   top: 6px;
   left: 6px;
-  padding: 2px 6px;
+  padding: 3px 8px;
   border-radius: 4px;
   background: var(--_gengage-discount-color);
   color: #fff;
@@ -4096,6 +4109,13 @@
 .gengage-chat-comparison--mobile {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+  position: relative;
+}
+
+/* Scroll hint — right-edge fade signals horizontal scrollability */
+.gengage-chat-comparison--mobile {
+  -webkit-mask-image: linear-gradient(to right, #000 85%, transparent);
+  mask-image: linear-gradient(to right, #000 85%, transparent);
 }
 
 .gengage-chat-comparison--mobile .gengage-chat-comparison-table {

--- a/src/chat/components/renderUISpec.ts
+++ b/src/chat/components/renderUISpec.ts
@@ -25,7 +25,12 @@ import { renderHandoffNotice } from './HandoffNotice.js';
 import { renderProductSummaryCard } from './ProductSummaryCard.js';
 import { createQuantityStepper } from '../../common/quantity-stepper.js';
 import { isSafeUrl, safeSetAttribute } from '../../common/safe-html.js';
-import { clampRating, clampDiscount, addImageErrorHandler, renderStarRating } from '../../common/product-utils.js';
+import {
+  clampRating,
+  clampDiscount,
+  addImageErrorHandler,
+  createStarRatingElement,
+} from '../../common/product-utils.js';
 
 export type UISpecRenderContext = ChatUISpecRenderContext;
 
@@ -246,7 +251,7 @@ function renderProductCard(element: UIElement, ctx: UISpecRenderContext): HTMLEl
   if (typeof rating === 'number' && Number.isFinite(rating)) {
     const ratingRow = document.createElement('div');
     ratingRow.className = 'gengage-chat-product-card-rating';
-    ratingRow.textContent = renderStarRating(rating);
+    ratingRow.appendChild(createStarRatingElement(rating));
     if (typeof reviewCount === 'number' && Number.isFinite(reviewCount)) {
       const count = document.createElement('span');
       count.className = 'gengage-chat-product-card-review-count';

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -864,15 +864,25 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       return;
     }
 
-    // Keep panel visible during search — show loading skeleton instead of collapsing.
-    // Skip for preservePanel actions (like/addToCart) that shouldn't disrupt current panel.
-    if (!options?.preservePanel) {
-      if (this._drawer?.hasPanelContent()) {
-        this._drawer.showPanelLoading();
+    // Preserve panel during the request — don't clear or show loading skeleton
+    // until the backend explicitly signals new panel content (panelLoading event).
+    // The snapshot is deferred: only cloned when panelLoading arrives, so the
+    // happy path (backend sends new content) pays no cloning cost.
+    let prePanelSnapshot: HTMLElement | null = null;
+    const snapshotPanelIfNeeded = (): void => {
+      if (prePanelSnapshot || options?.preservePanel) return;
+      const contentEl = this._drawer?.getPanelContentElement();
+      if (contentEl) prePanelSnapshot = contentEl.cloneNode(true) as HTMLElement;
+    };
+    const restoreOrClearPanel = (): void => {
+      if (!this._drawer?.isPanelLoading()) return;
+      if (prePanelSnapshot) {
+        this._drawer.setPanelContent(prePanelSnapshot);
       } else {
-        this._drawer?.clearPanel();
+        this._drawer.clearPanel();
       }
-    }
+      prePanelSnapshot = null;
+    };
 
     // Show typing indicator
     this._drawer?.showTypingIndicator();
@@ -1393,6 +1403,8 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             if (event.meta.panelLoading) {
               panelLoadingSeen = true;
               panelContentReceived = false;
+              // Snapshot current panel before replacing with skeleton
+              snapshotPanelIfNeeded();
               const pendingType =
                 typeof event.meta.panelPendingType === 'string' ? event.meta.panelPendingType : undefined;
               if (this._panel) this._panel.currentType = null;
@@ -1438,6 +1450,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             if (event.meta.analyzeAnimation) {
               panelLoadingSeen = true;
               panelContentReceived = false;
+              snapshotPanelIfNeeded();
               if (this._panel) this._panel.currentType = null;
               this._drawer?.showPanelLoading();
               // Default to product details title during analyze
@@ -1495,9 +1508,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           this._drawer?.removeTypingIndicator();
           // Capture panel state before resetting — needed for error gating below
           const hadPanelContent = panelContentReceived;
-          if (panelLoadingSeen && !panelContentReceived && this._drawer?.isPanelLoading()) {
-            this._drawer.clearPanel();
-          }
+          if (panelLoadingSeen && !panelContentReceived) restoreOrClearPanel();
           panelLoadingSeen = false;
           panelContentReceived = false;
           // Skip error toast when the stream already delivered user-facing content
@@ -1556,9 +1567,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           this._bridge?.send('isResponding', false);
           this._bridge?.send('loadingMessage', { text: null });
           this._drawer?.removeTypingIndicator();
-          if (panelLoadingSeen && !panelContentReceived && this._drawer?.isPanelLoading()) {
-            this._drawer.clearPanel();
-          }
+          if (panelLoadingSeen && !panelContentReceived) restoreOrClearPanel();
           panelLoadingSeen = false;
           panelContentReceived = false;
           // Detect failed PDP auto-launch: silent launch action that produced

--- a/src/common/action-router.ts
+++ b/src/common/action-router.ts
@@ -41,11 +41,7 @@ export function routeStreamAction(
       }
       const newTab = typeof action.newTab === 'boolean' ? action.newTab : undefined;
       if (handlers.navigate) {
-        if (newTab !== undefined) {
-          handlers.navigate({ url: action.url, newTab });
-        } else {
-          handlers.navigate({ url: action.url });
-        }
+        handlers.navigate({ url: action.url, ...(newTab !== undefined && { newTab }) });
         return;
       }
       defaultNavigate(action.url, newTab);
@@ -85,11 +81,7 @@ export function routeStreamAction(
         return;
       }
       const payload = isRecord(action.payload) ? action.payload : undefined;
-      if (payload !== undefined) {
-        handlers.scriptCall?.({ name: action.name, payload });
-      } else {
-        handlers.scriptCall?.({ name: action.name });
-      }
+      handlers.scriptCall?.({ name: action.name, ...(payload !== undefined && { payload }) });
       return;
     }
     default: {

--- a/src/common/debug.ts
+++ b/src/common/debug.ts
@@ -23,13 +23,10 @@ function isEnabled(): boolean {
 /** Log a debug message (only when gengage:debug is enabled). */
 export function debugLog(category: string, message: string, data?: unknown): void {
   if (!isEnabled()) return;
-  if (data !== undefined) {
-    // eslint-disable-next-line no-console -- debug utility, gated by localStorage flag
-    console.debug(`[gengage:${category}]`, message, data);
-  } else {
-    // eslint-disable-next-line no-console -- debug utility, gated by localStorage flag
-    console.debug(`[gengage:${category}]`, message);
-  }
+  const args: unknown[] = [`[gengage:${category}]`, message];
+  if (data !== undefined) args.push(data);
+  // eslint-disable-next-line no-console -- debug utility, gated by localStorage flag
+  console.debug(...args);
 }
 
 /** Reset the cached enabled state (for testing). */

--- a/src/common/events.ts
+++ b/src/common/events.ts
@@ -61,13 +61,12 @@ function extractFreeTextActionMessage(action: ActionPayload): string | null {
     return action.payload.trim();
   }
 
-  if (
-    typeof action.payload === 'object' &&
-    action.payload !== null &&
-    typeof (action.payload as Record<string, unknown>).text === 'string'
-  ) {
-    const text = String((action.payload as Record<string, unknown>).text).trim();
-    if (text.length > 0) return text;
+  if (typeof action.payload === 'object' && action.payload !== null) {
+    const payloadObj = action.payload as Record<string, unknown>;
+    if (typeof payloadObj.text === 'string') {
+      const text = payloadObj.text.trim();
+      if (text.length > 0) return text;
+    }
   }
 
   if (typeof action.title === 'string' && action.title.trim().length > 0) {

--- a/src/common/native-webview.ts
+++ b/src/common/native-webview.ts
@@ -194,14 +194,6 @@ function getNamedBridge(win: Window, interfaceName: string): { postMessage: (mes
   return null;
 }
 
-function getAndroidBridge(win: Window, interfaceName: string): { postMessage: (message: string) => void } | null {
-  return getNamedBridge(win, interfaceName);
-}
-
-function getReactNativeBridge(win: Window, interfaceName: string): { postMessage: (message: string) => void } | null {
-  return getNamedBridge(win, interfaceName);
-}
-
 export function detectNativeEnvironment(
   options: Pick<
     NativeWebViewBridgeOptions,
@@ -214,8 +206,8 @@ export function detectNativeEnvironment(
   const reactNativeInterfaceName = options.reactNativeInterfaceName ?? 'ReactNativeWebView';
 
   if (getIosPostMessage(win, iosHandlerName)) return 'ios';
-  if (getAndroidBridge(win, androidInterfaceName)) return 'android';
-  if (getReactNativeBridge(win, reactNativeInterfaceName)) return 'react-native';
+  if (getNamedBridge(win, androidInterfaceName)) return 'android';
+  if (getNamedBridge(win, reactNativeInterfaceName)) return 'react-native';
   return 'browser';
 }
 
@@ -280,13 +272,13 @@ export function createNativeWebViewBridge(options: NativeWebViewBridgeOptions = 
     }
 
     if (env === 'android') {
-      const androidBridge = getAndroidBridge(win, androidInterfaceName);
+      const androidBridge = getNamedBridge(win, androidInterfaceName);
       androidBridge?.postMessage(JSON.stringify(message));
       return;
     }
 
     if (env === 'react-native') {
-      const reactNativeBridge = getReactNativeBridge(win, reactNativeInterfaceName);
+      const reactNativeBridge = getNamedBridge(win, reactNativeInterfaceName);
       reactNativeBridge?.postMessage(JSON.stringify(message));
       return;
     }

--- a/src/common/product-utils.ts
+++ b/src/common/product-utils.ts
@@ -37,6 +37,45 @@ export function renderStarRating(rating: number, halfStars: boolean = true): str
 }
 
 /**
+ * Create a star rating DOM element with proper half-filled star rendering.
+ *
+ * Uses a CSS-clipped full star overlaid on an empty star for the half-star,
+ * giving a visually accurate half-filled appearance instead of the "½" character.
+ *
+ * @param rating - A numeric rating (will be clamped to 0–5).
+ * @returns An HTMLSpanElement containing the star icons.
+ */
+export function createStarRatingElement(rating: number): HTMLSpanElement {
+  const clamped = clampRating(rating);
+  const full = Math.floor(clamped);
+  const hasHalf = clamped - full >= 0.5;
+  const empty = 5 - full - (hasHalf ? 1 : 0);
+
+  const container = document.createElement('span');
+  container.className = 'gengage-star-rating';
+
+  if (full > 0) {
+    container.appendChild(document.createTextNode('\u2605'.repeat(full)));
+  }
+
+  if (hasHalf) {
+    const halfStar = document.createElement('span');
+    halfStar.className = 'gengage-star-half';
+    halfStar.textContent = '\u2606';
+    const filled = document.createElement('span');
+    filled.textContent = '\u2605';
+    halfStar.appendChild(filled);
+    container.appendChild(halfStar);
+  }
+
+  if (empty > 0) {
+    container.appendChild(document.createTextNode('\u2606'.repeat(empty)));
+  }
+
+  return container;
+}
+
+/**
  * Attach a one-time error handler that hides the image on load failure.
  *
  * Works with any HTMLImageElement. Hides the element by setting

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1674,8 +1674,9 @@ export interface NormalizedProduct {
 }
 
 export function productToNormalized(p: V1Product): NormalizedProduct {
-  const price = p.price_discounted != null && p.price_discounted > 0 ? p.price_discounted : p.price;
-  const originalPrice = p.price_discounted != null && p.price_discounted > 0 && p.price != null ? p.price : undefined;
+  const hasDiscount = p.price_discounted != null && p.price_discounted > 0;
+  const price = hasDiscount ? p.price_discounted : p.price;
+  const originalPrice = hasDiscount && p.price != null ? p.price : undefined;
 
   let discountPercent: number | undefined;
   if (originalPrice != null && price != null && originalPrice > 0) {

--- a/src/simrel/api.ts
+++ b/src/simrel/api.ts
@@ -6,7 +6,7 @@ import {
   normalizeProductGroupingsResponse,
 } from '../common/protocol-adapter.js';
 import type { NormalizedProduct } from '../common/protocol-adapter.js';
-import type { StreamEvent } from '../common/types.js';
+import type { StreamEvent, UIElement } from '../common/types.js';
 import type { ChatTransportConfig } from '../common/api-paths.js';
 
 export interface SimilarProductsRequest {
@@ -33,6 +33,19 @@ export interface ProductGroup {
   products: NormalizedProduct[];
 }
 
+function extractProductCardsFromSpec(elements: Record<string, UIElement>): NormalizedProduct[] {
+  const products: NormalizedProduct[] = [];
+  for (const el of Object.values(elements)) {
+    if (el.type === 'ProductCard' && el.props) {
+      const product = (el.props['product'] ?? el.props) as Record<string, unknown>;
+      if (typeof product['sku'] === 'string' && typeof product['name'] === 'string') {
+        products.push(product as unknown as NormalizedProduct);
+      }
+    }
+  }
+  return products;
+}
+
 function isNDJSONResponse(response: Response): boolean {
   const ct = response.headers.get('Content-Type') ?? '';
   return ct.includes('application/x-ndjson') || ct.includes('text/event-stream');
@@ -45,14 +58,7 @@ async function collectProductsFromStream(response: Response, signal?: AbortSigna
       const normalized = adaptBackendEvent(event as unknown as Record<string, unknown>);
       if (!normalized || normalized.type !== 'ui_spec') return;
 
-      for (const el of Object.values(normalized.spec.elements)) {
-        if (el.type === 'ProductCard' && el.props) {
-          const product = (el.props['product'] ?? el.props) as Record<string, unknown>;
-          if (typeof product['sku'] === 'string' && typeof product['name'] === 'string') {
-            products.push(product as unknown as NormalizedProduct);
-          }
-        }
-      }
+      products.push(...extractProductCardsFromSpec(normalized.spec.elements));
     },
   };
   if (signal !== undefined) opts.signal = signal;
@@ -112,14 +118,7 @@ async function collectGroupingsFromStream(response: Response, signal?: AbortSign
       }
 
       if (normalized.type === 'ui_spec' && currentGroup) {
-        for (const el of Object.values(normalized.spec.elements)) {
-          if (el.type === 'ProductCard' && el.props) {
-            const product = (el.props['product'] ?? el.props) as Record<string, unknown>;
-            if (typeof product['sku'] === 'string' && typeof product['name'] === 'string') {
-              currentGroup.products.push(product as unknown as NormalizedProduct);
-            }
-          }
-        }
+        currentGroup.products.push(...extractProductCardsFromSpec(normalized.spec.elements));
       }
     },
   };

--- a/src/simrel/components/ProductCard.ts
+++ b/src/simrel/components/ProductCard.ts
@@ -4,7 +4,7 @@ import type { PriceFormatConfig } from '../../common/price-formatter.js';
 import { formatPrice } from '../../common/price-formatter.js';
 import { sanitizeHtml, isSafeImageUrl } from '../../common/safe-html.js';
 import { createQuantityStepper } from '../../common/quantity-stepper.js';
-import { clampDiscount, addImageErrorHandler, renderStarRating } from '../../common/product-utils.js';
+import { clampDiscount, addImageErrorHandler, createStarRatingElement } from '../../common/product-utils.js';
 
 export interface ProductCardOptions {
   product: NormalizedProduct;
@@ -87,7 +87,7 @@ export function renderProductCard(options: ProductCardOptions): HTMLElement {
   if (product.rating != null && product.rating > 0) {
     const ratingEl = document.createElement('div');
     ratingEl.className = 'gengage-simrel-card-rating gengage-chat-product-card-rating';
-    ratingEl.textContent = renderStarRating(product.rating);
+    ratingEl.appendChild(createStarRatingElement(product.rating));
     if (product.reviewCount != null) {
       const count = document.createElement('span');
       count.className = 'gengage-simrel-card-review-count gengage-chat-product-card-review-count';
@@ -132,8 +132,13 @@ export function renderProductCard(options: ProductCardOptions): HTMLElement {
   });
   card.appendChild(cta);
 
-  // Add to cart stepper (only when in stock)
-  if (product.cartCode && product.inStock !== false) {
+  // Add to cart stepper or out-of-stock indicator
+  if (product.inStock === false) {
+    const oos = document.createElement('div');
+    oos.className = 'gengage-simrel-card-oos';
+    oos.textContent = i18n?.outOfStockLabel ?? 'Out of Stock';
+    card.appendChild(oos);
+  } else if (product.cartCode) {
     const cartCode = product.cartCode;
     const stepper = createQuantityStepper({
       compact: true,
@@ -142,7 +147,7 @@ export function renderProductCard(options: ProductCardOptions): HTMLElement {
         onAddToCart({ sku: product.sku, quantity, cartCode });
       },
     });
-    stepper.classList.add('gengage-simrel-atc', 'gengage-chat-product-card-atc');
+    stepper.classList.add('gengage-simrel-atc');
     card.appendChild(stepper);
   }
 

--- a/src/simrel/components/simrel.css
+++ b/src/simrel/components/simrel.css
@@ -28,23 +28,22 @@
 }
 
 .gengage-simrel-grid {
-  display: grid;
-  grid-template-columns: repeat(var(--gengage-simrel-columns, 4), minmax(0, 1fr));
-  gap: 14px;
-  padding: 10px 0 16px;
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  padding: 8px 0 12px;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: none;
+  scroll-snap-type: x proximity;
 }
 
-@media (max-width: 992px) {
-  .gengage-simrel-grid {
-    grid-template-columns: repeat(3, 1fr);
-  }
+.gengage-simrel-grid::-webkit-scrollbar {
+  display: none;
 }
 
-@media (max-width: 768px) {
-  .gengage-simrel-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 12px;
-  }
+.gengage-simrel-grid > * {
+  scroll-snap-align: start;
+  flex: 0 0 auto;
 }
 
 .gengage-simrel-card {
@@ -60,12 +59,9 @@
     box-shadow 0.2s ease,
     transform 0.1s ease;
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.06);
-}
-
-.gengage-simrel-grid .gengage-simrel-card.gengage-chat-product-card {
-  width: 100%;
-  min-width: 0;
-  max-width: none;
+  width: 160px;
+  min-width: 160px;
+  max-width: 160px;
 }
 
 .gengage-simrel-card:hover {
@@ -75,15 +71,15 @@
 
 .gengage-simrel-card-image {
   position: relative;
-  aspect-ratio: 1;
   overflow: hidden;
   background: #fff;
 }
 
 .gengage-simrel-card-image img {
   width: 100%;
-  height: 100%;
+  height: 120px;
   object-fit: contain;
+  display: block;
   padding: 8px;
   box-sizing: border-box;
 }
@@ -101,7 +97,6 @@
 }
 
 .gengage-simrel-card-info {
-  flex: 1;
   padding: 8px 10px 10px;
   display: flex;
   flex-direction: column;
@@ -125,7 +120,7 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
   text-overflow: ellipsis;
-  min-height: 0;
+  min-height: calc(2 * 1.35em);
 }
 
 .gengage-simrel-card-rating {
@@ -133,17 +128,30 @@
   color: var(--_gengage-rating-color);
 }
 
+.gengage-simrel-card-rating .gengage-star-half {
+  display: inline-block;
+  position: relative;
+}
+
+.gengage-simrel-card-rating .gengage-star-half > span {
+  position: absolute;
+  left: 0;
+  top: 0;
+  overflow: hidden;
+  width: 0.5em;
+}
+
 .gengage-simrel-card-review-count {
   color: var(--_gengage-text-secondary);
 }
 
 .gengage-simrel-card-price {
-  margin-top: auto;
   padding-top: 4px;
   display: flex;
+  flex-wrap: wrap;
   align-items: baseline;
   justify-content: center;
-  gap: 4px;
+  gap: 2px 4px;
 }
 
 .gengage-simrel-card-price-original {
@@ -160,17 +168,32 @@
 }
 
 .gengage-simrel-card-cta {
+  display: block;
+  margin-top: auto;
   width: 100%;
-  min-height: 40px;
+  padding: 8px 10px;
+  text-align: center;
   border: none;
   border-top: 1px solid var(--_gengage-surface-muted);
   border-radius: 0;
   background: transparent;
+  color: var(--gengage-primary-color, #3b82f6);
   font-family: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
   cursor: pointer;
+  transition:
+    color 0.15s ease,
+    background 0.15s ease;
 }
 
-.gengage-simrel-container .gengage-simrel-atc {
+.gengage-simrel-card-cta:hover {
+  color: var(--gengage-primary-color, #0b24d6);
+  background: var(--_gengage-surface-muted);
+}
+
+.gengage-simrel-card .gengage-simrel-atc {
   display: flex;
   width: 100%;
   border-top: 1px solid var(--_gengage-border-color);
@@ -181,7 +204,7 @@
   background: transparent;
 }
 
-.gengage-simrel-container .gengage-simrel-atc.gengage-qty-stepper {
+.gengage-simrel-card .gengage-simrel-atc.gengage-qty-stepper {
   gap: 0;
   overflow: hidden;
   border-radius: 0;
@@ -191,24 +214,24 @@
   border-bottom: none;
 }
 
-.gengage-simrel-container .gengage-simrel-atc .gengage-qty-btn {
+.gengage-simrel-card .gengage-simrel-atc .gengage-qty-btn {
   width: 32px;
   height: 36px;
   color: var(--_gengage-text-secondary);
   font-size: 14px;
 }
 
-.gengage-simrel-container .gengage-simrel-atc .gengage-qty-btn:hover:not(:disabled) {
+.gengage-simrel-card .gengage-simrel-atc .gengage-qty-btn:hover:not(:disabled) {
   background: var(--_gengage-surface-muted);
 }
 
-.gengage-simrel-container .gengage-simrel-atc .gengage-qty-value {
+.gengage-simrel-card .gengage-simrel-atc .gengage-qty-value {
   min-width: 24px;
   font-size: 13px;
   color: var(--_gengage-text-primary);
 }
 
-.gengage-simrel-container .gengage-simrel-atc .gengage-qty-submit {
+.gengage-simrel-card .gengage-simrel-atc .gengage-qty-submit {
   flex: 1;
   border-left: 1px solid var(--_gengage-border-color);
   background: transparent;
@@ -224,9 +247,20 @@
     background 0.15s ease;
 }
 
-.gengage-simrel-container .gengage-simrel-atc .gengage-qty-submit:hover {
+.gengage-simrel-card .gengage-simrel-atc .gengage-qty-submit:hover {
   color: var(--gengage-primary-color, #0b24d6);
   background: var(--_gengage-surface-muted);
+}
+
+.gengage-simrel-card-oos {
+  width: 100%;
+  padding: 8px 10px;
+  text-align: center;
+  border-top: 1px solid var(--_gengage-surface-muted);
+  color: var(--_gengage-text-secondary);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
 }
 
 .gengage-simrel-quick-actions {
@@ -260,7 +294,8 @@
 }
 
 .gengage-simrel-empty {
-  grid-column: 1 / -1;
+  width: 100%;
+  flex: 1 0 100%;
   text-align: center;
   padding: 40px 20px;
   color: var(--_gengage-text-secondary);
@@ -327,6 +362,18 @@
   .gengage-simrel-grid {
     gap: 10px;
     padding-top: 8px;
+    scroll-snap-type: x mandatory;
+  }
+
+  .gengage-simrel-card {
+    width: 200px;
+    min-width: 200px;
+    max-width: 200px;
+    scroll-snap-align: center;
+  }
+
+  .gengage-simrel-card-image img {
+    height: 140px;
   }
 
   .gengage-simrel-card-cta,
@@ -336,13 +383,13 @@
   }
 
   /* Ensure 44x44px minimum touch targets on mobile (WCAG 2.5.5) */
-  .gengage-simrel-container .gengage-simrel-atc .gengage-qty-btn {
+  .gengage-simrel-card .gengage-simrel-atc .gengage-qty-btn {
     width: 44px;
     height: 44px;
     font-size: 16px;
   }
 
-  .gengage-simrel-container .gengage-simrel-atc .gengage-qty-submit {
+  .gengage-simrel-card .gengage-simrel-atc .gengage-qty-submit {
     min-height: 44px;
     flex-basis: auto;
     border-left: 1px solid var(--_gengage-border-color);

--- a/src/simrel/locales/en.ts
+++ b/src/simrel/locales/en.ts
@@ -5,5 +5,6 @@ export const SIMREL_I18N_EN: SimRelI18n = {
   emptyStateMessage: 'No similar products found.',
   addToCartButton: 'Add to cart',
   ctaLabel: 'View',
+  outOfStockLabel: 'Out of Stock',
   priceSuffix: '',
 };

--- a/src/simrel/locales/tr.ts
+++ b/src/simrel/locales/tr.ts
@@ -5,5 +5,6 @@ export const SIMREL_I18N_TR: SimRelI18n = {
   emptyStateMessage: 'Benzer ürün bulunamadı.',
   addToCartButton: 'Sepete Ekle',
   ctaLabel: 'İncele',
+  outOfStockLabel: 'Stokta Yok',
   priceSuffix: ' TL',
 };

--- a/src/simrel/types.ts
+++ b/src/simrel/types.ts
@@ -82,6 +82,7 @@ export interface SimRelI18n {
   emptyStateMessage: string;
   addToCartButton: string;
   ctaLabel: string;
+  outOfStockLabel: string;
   /**
    * @deprecated Prefer `pricing` config on the widget for locale-aware formatting.
    * Kept for backwards compatibility with existing custom integrations.

--- a/tests/simrel-components.test.ts
+++ b/tests/simrel-components.test.ts
@@ -25,6 +25,8 @@ const defaultI18n: SimRelI18n = {
   similarProductsAriaLabel: 'Similar products',
   emptyStateMessage: 'No similar products found.',
   addToCartButton: 'Add to Cart',
+  ctaLabel: 'View',
+  outOfStockLabel: 'Out of Stock',
   priceSuffix: ' TL',
 };
 
@@ -62,7 +64,6 @@ describe('ProductCard', () => {
     expect(card.querySelector('.gengage-simrel-card-cta')?.classList.contains('gengage-chat-product-card-cta')).toBe(
       true,
     );
-    expect(card.querySelector('.gengage-simrel-atc')?.classList.contains('gengage-chat-product-card-atc')).toBe(true);
     expect(card.querySelector('.gengage-simrel-atc')?.classList.contains('gengage-qty-stepper--compact')).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

- **8 visual bug fixes** from screenshot QA campaign (164 screenshots, 4 themes, desktop+mobile):
  - Price formatting in CategoriesContainer (locale-aware via `formatPrice`)
  - Product card alignment symmetry (flex column layout, `margin-top: auto` on CTA)
  - SimRel price wrapping (`flex-wrap: wrap`)
  - AITopPicks discount badge overlap (moved to `right: 8px`)
  - Discount badge readability (padding increase)
  - Comparison table mobile scroll indicator (CSS `mask-image` gradient)
  - Chat input area disappearing (`flex-shrink: 0`)
  - Expert quality score "92/10" bug (normalize scores >10 to x/10 scale)

- **Panel preservation**: Details pane no longer goes blank when backend sends text-only responses. Snapshot is deferred to `panelLoading` event (zero cloning cost on happy path).

- **Shared product utilities**: Extracted `createStarRatingElement`, `clampRating`, `clampDiscount`, `addImageErrorHandler` to `common/product-utils.ts`.

- **SimRel out-of-stock indicator**: Products with `inStock: false` show a disabled label instead of CTA.

- **Code simplification**: ChatDrawer internals, debug logging, events, native-webview bridge, simrel API extraction.

## Test plan

- [x] `npm run format` passes (prettier + eslint + typecheck + catalog typecheck)
- [x] 1113 unit tests pass
- [x] Manual verification: Yataş chat panel preserved after asking question
- [x] E2E smoke tests on CI