### PR TITLE
fix: guard against destroy-during-init and abort-after-groupings (BUG-002, BUG-003)

### DIFF
--- a/src/common/widget-base.ts
+++ b/src/common/widget-base.ts
@@ -78,6 +78,7 @@ export abstract class BaseWidget<
       this.destroy();
       throw err;
     }
+    if (this._destroying) return;
     this.isInitialised = true;
     debugLog('lifecycle', `${this.constructor.name} ready`);
     this.emit('ready');

--- a/src/simrel/index.ts
+++ b/src/simrel/index.ts
@@ -255,6 +255,9 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
         }
       }
 
+      // If aborted (new SKU fetch started), bail out — new invocation owns _contentEl
+      if (signal.aborted) return;
+
       // Flat grid (no groupings or groupings failed)
       if (this._contentEl) {
         const gridSpec = this._buildProductsSpec(products);


### PR DESCRIPTION
## Why

Two async race conditions identified in the codebase audit:

### BUG-002 — Zombie widget after destroy-during-init

In `BaseWidget.init()`, if `destroy()` is called while `onInit()` is awaited (e.g., React
`useEffect` cleanup firing before init completes), the `onInit()` promise eventually resolves
and unconditionally sets `isInitialised = true` — overwriting the destroy's cleanup. This
creates a zombie widget where `isInitialised = true` and `_destroying = true` simultaneously.

Consequences:
- **Chat:** Leaked `window` resize listeners and a leaked `CommunicationBridge` (with its
  own `window` message listener), plus a stale `window.gengage.chat` public API
- **QNA/SimRel:** Wasted fetch attempts from `update()` on the zombie widget
- **All widgets:** Permanently rejects new `init()` calls (thinks it's already initialized)

Realistic trigger: React `useEffect` cleanup during SPA navigation while Chat's IndexedDB
restore (~1-50ms) or QNA/SimRel's network fetch (~100ms-5s) is in progress.

### BUG-003 — Stale product flash after abort in SimRel

In `GengageSimRel._fetchAndRender()`, the inner try-catch around `fetchProductGroupings`
(line 253) catches ALL errors including `AbortError`. When the user changes SKU mid-groupings-fetch:

1. New invocation aborts the old signal, clears `_contentEl`, shows spinner, starts fetching
2. Old invocation's inner catch catches the `AbortError` and falls through to flat grid rendering
3. Old invocation renders old-SKU products **on top of** the new spinner, fires spurious analytics
4. New invocation eventually replaces everything

This causes a brief but visible flash of wrong-SKU products and inflated analytics.

Both identified in codebase audit as **BUG-002** and **BUG-003** (see `BUGS.md`).

## What

Two one-line guards, one per bug:

1. **`src/common/widget-base.ts:81`** — Added `if (this._destroying) return;` after the
   try-catch around `onInit()` and before `this.isInitialised = true`. When `destroy()`
   ran during the await, init bails out instead of creating a zombie.

2. **`src/simrel/index.ts:256`** — Added `if (signal.aborted) return;` after the inner
   catch for `fetchProductGroupings` and before flat grid rendering. When a new fetch
   aborted the old one, the old invocation exits cleanly instead of rendering stale data.

## How

Both fixes follow the same pattern: check a flag that was set by the aborting/destroying
code path, and bail out before performing side effects (DOM mutation, state assignment,
analytics events).

- **BUG-002 guard:** `this._destroying` is set synchronously by `destroy()` during the
  await. When the microtask resumes, the guard prevents `isInitialised = true` and all
  subsequent post-init setup (public API registration, event listeners, bridge creation).

- **BUG-003 guard:** `signal.aborted` is set synchronously by `_abort()` in the new
  invocation. After the inner catch handles the `AbortError`, the guard prevents flat grid
  rendering and analytics events from the old invocation.

## Test plan

- [ ] `npm run typecheck` passes (verified)
- [ ] BUG-002: In a test harness, call `widget.init(config)` then `widget.destroy()` before
  init resolves — verify `isInitialised` remains `false` and no listeners leak
- [ ] BUG-003: Trigger SKU change during SimRel groupings fetch — verify no flash of old
  products and no duplicate analytics events
- [ ] Normal init/destroy lifecycle still works (no regression from the guard)
- [ ] SimRel groupings failure still falls through to flat grid (non-abort errors unaffected)