### PR TITLE
fix: mark KVKK consent only after user dismisses banner

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1157,9 +1157,12 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
               if (kvkkHtml) {
                 this._drawer?.showKvkkBanner(kvkkHtml, () => {
                   this._drawer?.hideKvkkBanner();
+                  markKvkkShown(acctId);
                 });
+              } else {
+                // No KVKK block found — mark as shown so we don't re-check
+                markKvkkShown(acctId);
               }
-              markKvkkShown(acctId);
             }
             displayText = stripKvkkBlock(displayText);
           }


### PR DESCRIPTION
## Summary

- **Bug:** `markKvkkShown(acctId)` was called synchronously outside the dismiss callback, recording consent in localStorage even if the user never interacted with the KVKK banner.
- **Fix:** Moved `markKvkkShown(acctId)` inside the dismiss callback so it only fires when the user actually dismisses the banner. Added an `else` branch that marks as shown when no KVKK block is found (so the check is not repeated unnecessarily).

## What changed

In `src/chat/index.ts`, the KVKK consent flow now:
1. If a KVKK block is extracted and the banner is shown, consent is marked **only when the user dismisses the banner** (inside the callback).
2. If `extractKvkkBlock` returns no content, consent is marked immediately (no banner to dismiss).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — all 1227 unit tests pass (including `kvkk.test.ts` and `kvkk-banner.test.ts`)