### PR TITLE
fix: widget lifecycle isVisible bypass and unhandled attachment errors

### DIFF
--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -589,7 +589,11 @@ export class ChatDrawer {
       if (file && file.type.startsWith('image/')) {
         e.preventDefault();
         if (this._onAttachment) {
-          this._onAttachment(file);
+          try {
+            this._onAttachment(file);
+          } catch (err) {
+            console.error('[gengage:chat] Attachment callback error:', err);
+          }
         } else {
           this.stageAttachment(file);
         }
@@ -605,7 +609,11 @@ export class ChatDrawer {
       const file = this._fileInput.files?.[0];
       if (file) {
         if (this._onAttachment) {
-          this._onAttachment(file);
+          try {
+            this._onAttachment(file);
+          } catch (err) {
+            console.error('[gengage:chat] Attachment callback error:', err);
+          }
         } else {
           this.stageAttachment(file);
         }
@@ -661,7 +669,11 @@ export class ChatDrawer {
       const file = e.dataTransfer?.files[0];
       if (file) {
         if (this._onAttachment) {
-          this._onAttachment(file);
+          try {
+            this._onAttachment(file);
+          } catch (err) {
+            console.error('[gengage:chat] Attachment callback error:', err);
+          }
         } else {
           this.stageAttachment(file);
         }

--- a/src/qna/index.ts
+++ b/src/qna/index.ts
@@ -74,7 +74,6 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
       await this._fetchAndRender(sku);
     }
 
-    this.isVisible = true;
     ga.trackInit('qna');
   }
 

--- a/src/simrel/index.ts
+++ b/src/simrel/index.ts
@@ -66,7 +66,6 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
 
     this._lastSku = config.sku;
     await this._fetchAndRender(config.sku);
-    this.isVisible = true;
     ga.trackInit('simrel');
   }
 


### PR DESCRIPTION
## Summary

- **BUG-3 (isVisible bypass):** QNA and SimRel `onInit()` methods set `this.isVisible = true` directly, bypassing `BaseWidget.show()` which guards on `if (this.isVisible) return`. This made `show()` a no-op so `onShow()` never fired, skipping QNA/SimRel fade-in animations. Removed the `this.isVisible = true` line from both widgets; `ga.trackInit()` calls remain.
- **BUG-5 (unhandled attachment errors):** Three `this._onAttachment(file)` call sites in `ChatDrawer.ts` (paste, file input change, drag-and-drop) lacked error handling. If the callback threw, the error would propagate unhandled and could break the input area. Wrapped each call in a try-catch that logs to `console.error`.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 1227 unit tests pass (`npm test`)
- [ ] Manual: open QNA widget, confirm fade-in animation plays on show
- [ ] Manual: open chat, paste/drop/select an image with a throwing `onAttachment` callback, confirm error is logged and input area remains functional