### PR TITLE
fix: panel and thread state management (5 bugs)

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1267,6 +1267,9 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
               this._appendSimilarsToPanel(panelSpec, renderContext);
             } else if (panelAction === 'append') {
               this._drawer?.appendPanelContent(this._renderUISpec(panelSpec, renderContext));
+              if (this._comparisonSelectMode) {
+                this._refreshComparisonUI();
+              }
             } else {
               // Reset comparison state when new panel content replaces the grid
               this._comparisonSelectMode = false;
@@ -1871,6 +1874,13 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
 
   /** Rewind the conversation to the given thread. */
   private _rollbackToThread(threadId: string): void {
+    // Validate thread ID exists in known threads
+    if (this._panel && this._panel.threads.length > 0 && !this._panel.threads.includes(threadId)) {
+      // Check if any message has this threadId as fallback
+      if (!this._messages.some((m) => m.threadId === threadId)) {
+        return; // Invalid thread ID — silently ignore
+      }
+    }
     this._currentThreadId = threadId;
     this._extendedModeManager?.setHiddenByUser(false);
 
@@ -1901,6 +1911,11 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       this._drawer?.clearPanel();
       this._currentPanelSource = null;
     }
+    if (restored && targetBot) {
+      // Update panel source so drilldown history captures the correct context.
+      // We can't reconstruct the exact spec, so clear it to prevent stale history pushes.
+      this._currentPanelSource = null;
+    }
     // Always update topbar navigation state for the new thread position
     const panelType = this._panel!.currentType ?? '';
     this._panel?.updateTopBar(panelType);
@@ -1909,23 +1924,18 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     this._drawer?.setPills([]);
 
     // Load context from IndexedDB for the target thread so the next request
-    // sends the correct historical context (not the latest one).
+    // sends the correct historical context, then prune future entries.
     if (this._session?.db && this.config.session?.sessionId) {
-      this._session?.db
-        .loadContext(this.config.session.sessionId, threadId)
-        .then((ctx) => {
+      const sid = this.config.session.sessionId;
+      void (async () => {
+        try {
+          const ctx = await this._session?.db?.loadContext(sid, threadId);
           if (ctx) this._lastBackendContext = ctx.context;
-        })
-        .catch(() => {
+          await this._session?.db?.deleteContextsAfterThread(sid, threadId);
+        } catch {
           /* non-fatal */
-        });
-    }
-
-    // Prune future context entries from IndexedDB
-    if (this._session?.db && this.config.session?.sessionId) {
-      this._session?.db.deleteContextsAfterThread(this.config.session.sessionId, threadId).catch(() => {
-        /* non-fatal */
-      });
+        }
+      })();
     }
   }
 
@@ -2032,6 +2042,10 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     // Restore thread cursors and creation timestamp
     this._currentThreadId = session.currentThreadId;
     this._lastThreadId = session.lastThreadId;
+    // Validate thread invariants — corrupted IDB data must not break navigation
+    if (this._currentThreadId && this._lastThreadId && this._currentThreadId > this._lastThreadId) {
+      this._currentThreadId = this._lastThreadId;
+    }
     this._chatCreatedAt = session.createdAt;
 
     // Restore panel threads and thumbnail entries


### PR DESCRIPTION
## Summary

Fixes 5 related panel/thread state management bugs in `src/chat/index.ts`:

- **BUG-6:** `_rollbackToThread` did not clear `_currentPanelSource` after a successful panel snapshot restore, leaving stale state that could corrupt drilldown history pushes. Now explicitly sets `_currentPanelSource = null` on successful restore.

- **BUG-7:** `_restoreFromIndexedDB` restored thread IDs from IndexedDB without validating invariants. Corrupted IDB data where `currentThreadId > lastThreadId` could break thread navigation. Now clamps `currentThreadId` to `lastThreadId` when the invariant is violated.

- **BUG-8:** When panel content was appended (e.g., similars pagination) during active comparison select mode, the comparison UI checkboxes were not refreshed on the newly added cards. Now calls `_refreshComparisonUI()` after the append path when comparison mode is active.

- **BUG-9:** Two fire-and-forget IDB operations in `_rollbackToThread` (load context + delete future contexts) ran as independent unordered promises. The delete could race ahead of the load. Now serialized into a single `async` IIFE with `try/catch`.

- **BUG-10:** `_rollbackToThread` accepted any thread ID without validation. Invalid thread IDs (not in panel threads or messages) could corrupt navigation state. Now validates the thread ID exists before proceeding; silently ignores invalid IDs.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 1227 unit tests pass (`npm test`)
- [ ] Manual: open chat, navigate threads, verify panel restores correctly
- [ ] Manual: trigger comparison mode, paginate similars, verify checkboxes appear on new cards
- [ ] Manual: verify thread rollback with invalid thread ID is silently ignored