### PR TITLE
fix: i18n — Turkish diacriticals, SimRel error i18n, protocol adapter fallback

### DIFF
--- a/catalog/src/utils/noop-context.ts
+++ b/catalog/src/utils/noop-context.ts
@@ -146,6 +146,8 @@ export function createNoopSimrelContext(): SimRelUISpecRenderContext {
       outOfStockLabel: 'Out of Stock',
       decreaseLabel: 'Decrease',
       increaseLabel: 'Increase',
+      errorLoadingMessage: 'Could not load similar products.',
+      retryButtonText: 'Try again',
       priceSuffix: ' TL',
     },
     pricing: {

--- a/src/common/global-error-toast.ts
+++ b/src/common/global-error-toast.ts
@@ -13,7 +13,7 @@ let dismissTimer: ReturnType<typeof setTimeout> | null = null;
 
 export function getGlobalErrorMessage(locale?: string): string {
   if (typeof locale === 'string' && locale.toLowerCase().startsWith('tr')) {
-    return 'Baglanti sorunu olustu. Lutfen tekrar deneyin.';
+    return 'Bağlantı sorunu oluştu. Lütfen tekrar deneyin.';
   }
   return 'Connection issue. Please try again.';
 }

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1277,7 +1277,7 @@ function adaptGetGroundingReview(event: V1GetGroundingReview): StreamEventUISpec
   const action = requestDetailsToAction(
     event.payload.requestDetails,
     firstNonEmptyString(event.payload.review_count, event.payload.text, event.payload.title) ??
-      'Urun yorumlarini goster',
+      'Show product reviews',
   );
   if (!action) {
     return {

--- a/src/simrel/index.ts
+++ b/src/simrel/index.ts
@@ -313,13 +313,11 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
         const errorEl = document.createElement('div');
         errorEl.className = 'gengage-simrel-error';
         const msgEl = document.createElement('span');
-        msgEl.textContent = this.config.locale?.startsWith('tr')
-          ? 'Benzer \u00FCr\u00FCnler y\u00FCklenemedi.'
-          : 'Could not load similar products.';
+        msgEl.textContent = this._i18n.errorLoadingMessage;
         errorEl.appendChild(msgEl);
         const retryBtn = document.createElement('button');
         retryBtn.className = 'gengage-simrel-retry';
-        retryBtn.textContent = this.config.locale?.startsWith('tr') ? 'Tekrar dene' : 'Try again';
+        retryBtn.textContent = this._i18n.retryButtonText;
         retryBtn.addEventListener('click', () => {
           void this._fetchAndRender(this.config.sku);
         });

--- a/src/simrel/locales/en.ts
+++ b/src/simrel/locales/en.ts
@@ -8,5 +8,7 @@ export const SIMREL_I18N_EN: SimRelI18n = {
   outOfStockLabel: 'Out of Stock',
   decreaseLabel: 'Decrease',
   increaseLabel: 'Increase',
+  errorLoadingMessage: 'Could not load similar products.',
+  retryButtonText: 'Try again',
   priceSuffix: '',
 };

--- a/src/simrel/locales/tr.ts
+++ b/src/simrel/locales/tr.ts
@@ -8,5 +8,7 @@ export const SIMREL_I18N_TR: SimRelI18n = {
   outOfStockLabel: 'Stokta Yok',
   decreaseLabel: 'Azalt',
   increaseLabel: 'Artır',
+  errorLoadingMessage: 'Benzer ürünler yüklenemedi.',
+  retryButtonText: 'Tekrar dene',
   priceSuffix: ' TL',
 };

--- a/src/simrel/types.ts
+++ b/src/simrel/types.ts
@@ -95,6 +95,10 @@ export interface SimRelI18n {
   outOfStockLabel: string;
   decreaseLabel: string;
   increaseLabel: string;
+  /** Inline error message shown when similar products fail to load. */
+  errorLoadingMessage: string;
+  /** Retry button label shown alongside the error message. */
+  retryButtonText: string;
   /**
    * @deprecated Prefer `pricing` config on the widget for locale-aware formatting.
    * Kept for backwards compatibility with existing custom integrations.


### PR DESCRIPTION
## Summary

Fixes three i18n bugs that caused hardcoded or malformed strings in the SDK:

- **BUG-4:** Turkish diacriticals missing in `global-error-toast.ts` — `Baglanti sorunu olustu` changed to `Bağlantı sorunu oluştu` with proper Turkish characters (ğ, ı, ş, ü).
- **BUG-15:** SimRel inline error messages bypassed the i18n system with hardcoded locale checks. Added `errorLoadingMessage` and `retryButtonText` keys to `SimRelI18n` type, both locale files (TR/EN), and the catalog noop-context. The widget now uses `this._i18n.errorLoadingMessage` / `this._i18n.retryButtonText` instead of inline `locale?.startsWith('tr')` ternaries.
- **BUG-16:** Protocol adapter had a hardcoded Turkish fallback `'Urun yorumlarini goster'` (also missing diacriticals). Changed to English `'Show product reviews'` since the adapter has no locale context and English is the safer international default.

## Changed files

- `src/common/global-error-toast.ts` — fix Turkish diacriticals (BUG-4)
- `src/common/protocol-adapter.ts` — English fallback for grounding review label (BUG-16)
- `src/simrel/types.ts` — add `errorLoadingMessage` and `retryButtonText` to `SimRelI18n`
- `src/simrel/locales/tr.ts` — add Turkish translations for new keys
- `src/simrel/locales/en.ts` — add English translations for new keys
- `src/simrel/index.ts` — use i18n keys instead of hardcoded strings (BUG-15)
- `catalog/src/utils/noop-context.ts` — add new keys to noop SimRel context

## Test plan

- [x] `npm run typecheck` passes
- [x] All 1227 unit tests pass (including locale-completeness test which validates EN/TR key parity)
- [ ] Manual: `npm run dev -- koctascomtr --sku=1000465056` — verify SimRel error state shows localized strings when backend is unreachable
- [ ] Manual: verify global error toast shows proper Turkish diacriticals