### PR TITLE
chore: catalog merchant dropdown, code quality cleanup

### DIFF
--- a/catalog/src/layout.ts
+++ b/catalog/src/layout.ts
@@ -1,7 +1,7 @@
 import { ROUTES, navigate, getCurrentPath, getBreadcrumb } from './router.js';
 import type { Route } from './router.js';
 import { applyTheme } from './utils/theme-applicator.js';
-import { getMerchantConfig } from './merchant-configs.js';
+import { getMerchantConfig, getMerchantIds } from './merchant-configs.js';
 
 let contentEl: HTMLElement | null = null;
 let breadcrumbEl: HTMLElement | null = null;
@@ -84,21 +84,7 @@ export function mountLayout(root: HTMLElement): HTMLElement {
   noneOpt.textContent = 'None (default)';
   themeDropdownEl.appendChild(noneOpt);
 
-  const merchantIds = [
-    'koctascomtr',
-    'n11com',
-    'hepsiburadacom',
-    'arcelikcomtr',
-    'yatasbeddingcomtr',
-    'trendyolcom',
-    'boynercomtr',
-    'evideacom',
-    'aygazcomtr',
-    'otokoccomtr',
-    'divanpastanelericomtr',
-    'screwfixcom',
-  ];
-  for (const id of merchantIds) {
+  for (const id of getMerchantIds()) {
     const opt = document.createElement('option');
     opt.value = id;
     opt.textContent = id;

--- a/catalog/src/merchant-configs.ts
+++ b/catalog/src/merchant-configs.ts
@@ -194,24 +194,6 @@ const MERCHANT_CONFIGS: Record<string, MerchantConfig> = {
     },
   },
 
-  otokoccomtr: {
-    accountId: 'otokoccomtr',
-    locale: 'tr',
-    theme: {
-      primaryColor: '#003087',
-      primaryForeground: '#ffffff',
-      backgroundColor: '#ffffff',
-      foregroundColor: '#333333',
-      borderRadius: '8px',
-      fontFamily: '"Roboto", Arial, sans-serif',
-      fontSize: '14px',
-    },
-    chatI18n: {
-      inputPlaceholder: 'Araç veya hizmet arayın',
-      poweredBy: 'Otokoç AI Asistan',
-    },
-  },
-
   divanpastanelericomtr: {
     accountId: 'divanpastanelericomtr',
     locale: 'tr',

--- a/src/chat/api.ts
+++ b/src/chat/api.ts
@@ -101,8 +101,10 @@ export function enrichActionPayload(
       const additions: Record<string, unknown> = {
         is_launcher: 0,
       };
-      if (action.title) additions['text'] = action.title;
-      if (action.title) additions['input'] = action.title;
+      if (action.title) {
+        additions['text'] = action.title;
+        additions['input'] = action.title;
+      }
       return { ...action, payload: merge(additions) };
     }
 

--- a/src/chat/components/renderUISpec.ts
+++ b/src/chat/components/renderUISpec.ts
@@ -886,9 +886,7 @@ function renderProductDetailTabs(
 
     const panel = document.createElement('div');
     panel.className = 'gengage-chat-product-detail-tab-panel';
-    if (!description) {
-      // Show specs by default if no description
-    } else {
+    if (description) {
       panel.style.display = 'none';
     }
 

--- a/tests/wcag-contrast.test.ts
+++ b/tests/wcag-contrast.test.ts
@@ -26,7 +26,6 @@ const MERCHANT_THEMES: Array<{ name: string; primary: string; foreground: string
   { name: 'boynercomtr', primary: '#000000', foreground: '#ffffff' },
   { name: 'evideacom', primary: '#e84393', foreground: '#ffffff' },
   { name: 'aygazcomtr', primary: '#e30613', foreground: '#ffffff' },
-  { name: 'otokoccomtr', primary: '#003087', foreground: '#ffffff' },
   { name: 'divanpastanelericomtr', primary: '#8b1a2d', foreground: '#ffffff' },
   { name: 'screwfixcom', primary: '#f6a623', foreground: '#1a1a1a' },
 ];
@@ -135,7 +134,7 @@ describe('WCAG contrast ratio', () => {
     }
   });
 
-  it('all 12 merchants are covered', () => {
-    expect(MERCHANT_THEMES).toHaveLength(12);
+  it('all 11 merchants are covered', () => {
+    expect(MERCHANT_THEMES).toHaveLength(11);
   });
 });


### PR DESCRIPTION
## Summary

- **BUG-12:** Replace hardcoded merchant ID list in `catalog/src/layout.ts` with dynamic `getMerchantIds()` call from `merchant-configs.ts`. The theme dropdown now automatically includes all configured merchants.
- **BUG-31:** Merge duplicate `if (action.title)` conditions in `src/chat/api.ts` `enrichActionPayload` for `findSimilar` into a single block.
- **BUG-32:** Remove dead code branch in `src/chat/components/renderUISpec.ts` — empty `if (!description)` block simplified to `if (description) { panel.style.display = 'none'; }`.
- **BUG-33:** Remove `otokoccomtr` entry from `catalog/src/merchant-configs.ts` (no corresponding demo directory exists). Updated WCAG contrast test accordingly.

## Test plan

- [x] `npm run typecheck` passes
- [x] All 1225 unit tests pass (`npm test`)
- [ ] `npm run catalog` — verify theme dropdown shows all merchants dynamically