### PR TITLE
Error message handling

### DIFF
--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -1259,6 +1259,15 @@ export class ChatDrawer {
   /** Show error with recovery action pills ("Try again" + "Ask something else"). */
   showErrorWithRecovery(message: string, actions: { onRetry: () => void; onNewQuestion: () => void }): void {
     this.showError(message);
+    this.setRecoveryPills(actions);
+  }
+
+  /** Recovery pills only — error copy is shown as a normal assistant message. */
+  showRecoveryPillsOnly(actions: { onRetry: () => void; onNewQuestion: () => void }): void {
+    this.setRecoveryPills(actions);
+  }
+
+  private setRecoveryPills(actions: { onRetry: () => void; onNewQuestion: () => void }): void {
     this.setPills([
       { label: this.i18n.tryAgainButton, onAction: actions.onRetry },
       { label: this.i18n.askSomethingElseButton, onAction: actions.onNewQuestion },

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -2371,7 +2371,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             if (idx >= 0) this._messages.splice(idx, 1);
           };
 
-          let removedAssistantPlaceholderForStrip = false;
+          let placeholderBubbleRemoved = false;
 
           const applyStreamErrorRecovery = (): void => {
             if (shouldSuppressOfflineError) return;
@@ -2383,9 +2383,8 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
               this._consecutiveErrorCount = 1;
               this._lastErrorMessage = errMsg;
             }
-            const backendDetail = typeof err.message === 'string' ? err.message.trim() : '';
-            const displayText =
-              backendDetail.length > 0 ? backendDetail : this._i18n.errorMessage;
+            const backendDetail = err.message.trim();
+            const displayText = backendDetail.length > 0 ? backendDetail : this._i18n.errorMessage;
             const recoveryActions = {
               onRetry: () => {
                 if (this._lastSentAction) {
@@ -2399,14 +2398,14 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
 
             if (this._consecutiveErrorCount >= 2) {
               removeAssistantPlaceholderBubble();
-              removedAssistantPlaceholderForStrip = true;
+              placeholderBubbleRemoved = true;
               this._drawer?.showErrorWithRecovery(this._i18n.accountInactiveMessage, recoveryActions);
               return;
             }
 
             if (shouldShowStreamErrorAsRedStrip(err, displayText)) {
               removeAssistantPlaceholderBubble();
-              removedAssistantPlaceholderForStrip = true;
+              placeholderBubbleRemoved = true;
               this._drawer?.showErrorWithRecovery(displayText, recoveryActions);
               return;
             }
@@ -2445,18 +2444,22 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             this._pdpPrimingInFlight = false;
             this._flushQueuedUserMessages();
           }
-          if (!removedAssistantPlaceholderForStrip && botMsg.status === 'streaming') {
+          if (!placeholderBubbleRemoved && botMsg.status === 'streaming') {
             botMsg.status = 'error';
           }
 
-          this.track(
-            streamErrorEvent(this.analyticsContext(), {
-              request_id: requestId,
-              error_code: 'STREAM_ERROR',
-              error_message: err.message,
-              widget: 'chat',
-            }),
-          );
+          // Skip analytics for suppressed offline errors (consistent with the
+          // early return in the !hasContent branch above).
+          if (!shouldSuppressOfflineError) {
+            this.track(
+              streamErrorEvent(this.analyticsContext(), {
+                request_id: requestId,
+                error_code: 'STREAM_ERROR',
+                error_message: err.message,
+                widget: 'chat',
+              }),
+            );
+          }
         },
         onDone: () => {
           if (streamController) this._abortControllers.delete(streamController);

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -71,6 +71,7 @@ import { SessionPersistence } from './session-persistence.js';
 import { ChatPresentationState, getLatestUnreadAssistantThreadId } from './chat-presentation-state.js';
 import { invalidateChatScrollCache } from './utils/get-chat-scroll-element.js';
 import { isLikelyConnectivityIssue } from '../common/global-error-toast.js';
+import { shouldShowStreamErrorAsRedStrip } from './stream-error-display.js';
 import {
   containsKvkk,
   isKvkkShown,
@@ -2267,26 +2268,86 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           // Skip error handling for aborted/superseded requests (including when no active request)
           if (!isPreservePanel && threadId !== this._activeRequestThreadId) return;
           streamDone = true;
+          this._activeTypewriter?.cancel();
+          this._activeTypewriter = null;
           syncPanelAiAnalysisZone();
           pendingPanelAiSpec = null;
           this._bridge?.send('isResponding', false);
           this._bridge?.send('loadingMessage', { text: null });
           this._drawer?.removeTypingIndicator();
+          this._drawer?.clearInputAreaChips();
           // Capture panel state before resetting — needed for error gating below
           const hadPanelContent = panelContentReceived;
           if (panelLoadingSeen && !panelContentReceived) restoreOrClearPanel();
           panelLoadingSeen = false;
           panelContentReceived = false;
-          // Skip error toast when the stream already delivered user-facing content
-          // (bot text, panel content, or silent auto-launch). Showing a generic
-          // error on top of an already-rendered assistant response is confusing.
+          // When the stream already delivered partial content (bot text, panel, etc.),
+          // still show backend error text + recovery pills — not only clear stale chips.
           const hasContent =
             botMsg.silent ||
             (botMsg.content != null && botMsg.content.length > 0) ||
             localBotText.length > 0 ||
             hadPanelContent;
+          const shouldSuppressOfflineError =
+            typeof navigator !== 'undefined' && navigator.onLine === false && isLikelyConnectivityIssue(err);
+
+          const removeAssistantPlaceholderBubble = (): void => {
+            this._shadow?.querySelector(`[data-message-id="${CSS.escape(botMsg.id)}"]`)?.remove();
+            const idx = this._messages.indexOf(botMsg);
+            if (idx >= 0) this._messages.splice(idx, 1);
+          };
+
+          let removedAssistantPlaceholderForStrip = false;
+
+          const applyStreamErrorRecovery = (): void => {
+            if (shouldSuppressOfflineError) return;
+            this.emit('error', err);
+            const errMsg = err.message;
+            if (errMsg === this._lastErrorMessage) {
+              this._consecutiveErrorCount++;
+            } else {
+              this._consecutiveErrorCount = 1;
+              this._lastErrorMessage = errMsg;
+            }
+            const backendDetail = typeof err.message === 'string' ? err.message.trim() : '';
+            const displayText =
+              backendDetail.length > 0 ? backendDetail : this._i18n.errorMessage;
+            const recoveryActions = {
+              onRetry: () => {
+                if (this._lastSentAction) {
+                  this._sendAction(this._lastSentAction.action, this._lastSentAction.options);
+                }
+              },
+              onNewQuestion: () => {
+                this._drawer?.focusInput();
+              },
+            };
+
+            if (this._consecutiveErrorCount >= 2) {
+              removeAssistantPlaceholderBubble();
+              removedAssistantPlaceholderForStrip = true;
+              this._drawer?.showErrorWithRecovery(this._i18n.accountInactiveMessage, recoveryActions);
+              return;
+            }
+
+            if (shouldShowStreamErrorAsRedStrip(err, displayText)) {
+              removeAssistantPlaceholderBubble();
+              removedAssistantPlaceholderForStrip = true;
+              this._drawer?.showErrorWithRecovery(displayText, recoveryActions);
+              return;
+            }
+
+            botMsg.content = displayText;
+            botMsg.status = 'done';
+            const bubbleHtml = sanitizeHtml(displayText.replace(/\r\n/g, '\n').split('\n').join('<br />'));
+            this._ensureAssistantMessageRendered(botMsg);
+            this._drawer?.updateBotMessage(botMsg.id, bubbleHtml);
+            this._drawer?.showRecoveryPillsOnly(recoveryActions);
+          };
+
           if (!hasContent) {
             if (isPdpAutoLaunch || this._hasUnavailableProductContext()) {
+              this._drawer?.setPills([]);
               // Show soft fallback instead of generic error for auto-launch
               const fallback = this._i18n.productNotFoundMessage;
               botMsg.content = fallback;
@@ -2295,60 +2356,22 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
               this._drawer?.updateBotMessage(botMsg.id, fallback);
               this._markUnavailableProductContext();
             } else {
-              // Show error inline in the chat — not as a global toast.
-              // The user is in an active conversation; a toast on top of the
-              // chat is confusing and can overlap with prior bot messages.
-              this.emit('error', err);
-
-              const shouldSuppressOfflineError =
-                typeof navigator !== 'undefined' && navigator.onLine === false && isLikelyConnectivityIssue(err);
+              applyStreamErrorRecovery();
               if (shouldSuppressOfflineError) {
                 return;
               }
-
-              // Track consecutive identical errors — repeated failures suggest
-              // the account is inactive or backend is unreachable.
-              const errMsg = err.message;
-              if (errMsg === this._lastErrorMessage) {
-                this._consecutiveErrorCount++;
-              } else {
-                this._consecutiveErrorCount = 1;
-                this._lastErrorMessage = errMsg;
-              }
-
-              if (this._consecutiveErrorCount >= 2) {
-                // Escalate: show account-inactive message with recovery pills
-                this._drawer?.showErrorWithRecovery(this._i18n.accountInactiveMessage, {
-                  onRetry: () => {
-                    if (this._lastSentAction) {
-                      this._sendAction(this._lastSentAction.action, this._lastSentAction.options);
-                    }
-                  },
-                  onNewQuestion: () => {
-                    this._drawer?.focusInput();
-                  },
-                });
-              } else {
-                // First error: show standard error with retry + recovery pills
-                this._drawer?.showErrorWithRecovery(this._i18n.errorMessage, {
-                  onRetry: () => {
-                    if (this._lastSentAction) {
-                      this._sendAction(this._lastSentAction.action, this._lastSentAction.options);
-                    }
-                  },
-                  onNewQuestion: () => {
-                    this._drawer?.focusInput();
-                  },
-                });
-              }
+            }
+          } else {
+            this._drawer?.setPills([]);
+            if (!botMsg.silent) {
+              applyStreamErrorRecovery();
             }
           }
           if (isPdpAutoLaunch) {
             this._pdpPrimingInFlight = false;
             this._flushQueuedUserMessages();
           }
-          // Only overwrite status if message hasn't already completed (isFinal text chunk sets 'done')
-          if (botMsg.status === 'streaming') {
+          if (!removedAssistantPlaceholderForStrip && botMsg.status === 'streaming') {
             botMsg.status = 'error';
           }
 

--- a/src/chat/stream-error-display.ts
+++ b/src/chat/stream-error-display.ts
@@ -1,0 +1,56 @@
+import { isLikelyConnectivityIssue } from '../common/global-error-toast.js';
+
+const HTTP_STATUS_PREFIX = /^HTTP\s+\d{3}\b/i;
+
+const INFRA_MESSAGE_PATTERNS = [
+  /response body is null/i,
+  /streaming not supported/i,
+  /ECONNREFUSED/i,
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /socket hang up/i,
+  /net::ERR_/i,
+  /502\s+bad gateway/i,
+  /503\s+service unavailable/i,
+  /504\s+gateway timeout/i,
+] as const;
+
+const TECHNICAL_DUMP_PATTERNS = [
+  /Traceback\s*\(/i,
+  /\bSyntaxError\b/,
+  /\bReferenceError\b/,
+  /\bTypeError\s*:/,
+  /\bat\s+[\w./()[\]<>-]+:\d+:\d+/,
+  /\n\s+at\s+\w/,
+  /undefined is not/i,
+  /is not a function/i,
+  /<anonymous>/i,
+  /ChunkLoadError/i,
+  /UnhandledPromiseRejection/i,
+] as const;
+
+/** Above this length, treat as dump / transport payload — show red strip instead of a chat bubble. */
+const MAX_CHAT_BUBBLE_ERROR_LENGTH = 720;
+
+/**
+ * Use the red inline error strip (+ recovery pills) instead of a normal assistant bubble when the
+ * failure looks like transport, HTTP, or an obvious technical dump. User-facing backend messages
+ * (e.g. output_text with is_error) stay in the conversation as a chat message.
+ */
+export function shouldShowStreamErrorAsRedStrip(err: Error, displayText: string): boolean {
+  if (isLikelyConnectivityIssue(err)) return true;
+
+  const raw = err.message.trim();
+  if (HTTP_STATUS_PREFIX.test(raw)) return true;
+  if (INFRA_MESSAGE_PATTERNS.some((p) => p.test(raw))) return true;
+
+  const text = displayText.trim();
+  if (text.length > MAX_CHAT_BUBBLE_ERROR_LENGTH) return true;
+
+  const lines = text.split(/\n/).length;
+  if (lines >= 6) return true;
+  if (TECHNICAL_DUMP_PATTERNS.some((p) => p.test(text))) return true;
+  if (lines >= 3 && /\bat\s+/.test(text)) return true;
+
+  return false;
+}

--- a/tests/chat-error-recovery.test.ts
+++ b/tests/chat-error-recovery.test.ts
@@ -102,6 +102,17 @@ describe('ChatDrawer.showErrorWithRecovery', () => {
 
     container.remove();
   });
+
+  it('showRecoveryPillsOnly sets pills without red error strip', () => {
+    const { container, drawer } = createDrawer();
+    drawer.showRecoveryPillsOnly({ onRetry: vi.fn(), onNewQuestion: vi.fn() });
+
+    expect(container.querySelector('.gengage-chat-error')).toBeNull();
+    const pills = container.querySelectorAll('.gengage-chat-pill');
+    expect(pills.length).toBe(2);
+
+    container.remove();
+  });
 });
 
 describe('ChatDrawer.showError scroll behavior', () => {

--- a/tests/stream-error-display.test.ts
+++ b/tests/stream-error-display.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { shouldShowStreamErrorAsRedStrip } from '../src/chat/stream-error-display.js';
+
+function err(message: string): Error {
+  return new Error(message);
+}
+
+describe('shouldShowStreamErrorAsRedStrip', () => {
+  it('returns true for HTTP status style messages', () => {
+    expect(shouldShowStreamErrorAsRedStrip(err('HTTP 503: Service Unavailable'), 'HTTP 503: Service Unavailable')).toBe(
+      true,
+    );
+  });
+
+  it('returns true for connectivity-style errors', () => {
+    expect(shouldShowStreamErrorAsRedStrip(err('Failed to fetch'), 'Failed to fetch')).toBe(true);
+  });
+
+  it('returns true for long or stack-like text', () => {
+    const dump = 'x'.repeat(800);
+    expect(shouldShowStreamErrorAsRedStrip(err('x'), dump)).toBe(true);
+    expect(
+      shouldShowStreamErrorAsRedStrip(
+        err('x'),
+        'Traceback (most recent call last):\n  File "a.py", line 1\n  File "b.py", line 2',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for short user-facing backend messages', () => {
+    expect(
+      shouldShowStreamErrorAsRedStrip(
+        err('Üzgünüm, bu ürün için stok bilgisine ulaşılamadı.'),
+        'Üzgünüm, bu ürün için stok bilgisine ulaşılamadı.',
+      ),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Error mesajları server error olmadığı sürece normal balon şeklinde çıkmalı, şu anda backendden gelen "Anlayamadım" tarzı mesajları hiç göstermeden "Hata oluştu" yazıyoruz kırmızı bir banner ile. Onun önüne geçip daha iyi bilgilendirme amacı ile değişikliği yaptık. Bu değişiklik ile server veya kod hatalarında kırmızı banner gözükürken daha normal, chatin kullanıcıya derdini anlatabileceği kısımlarda chat mesajı şeklinde gösteriyoruz.