### PR TITLE
feat(demos): Otokoç automotive dealer demo + ElevenLabs voice launcher

### DIFF
--- a/demos/otokoccomtr/glov-otokoccomtr-launcher.svg
+++ b/demos/otokoccomtr/glov-otokoccomtr-launcher.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <!-- Background circle -->
+  <circle cx="32" cy="32" r="32" fill="#0F2B5B"/>
+  <!-- Stylised "O" with car silhouette inside -->
+  <circle cx="32" cy="32" r="20" stroke="white" stroke-width="4" fill="none"/>
+  <!-- Car body -->
+  <path d="M16 34 C16 30 20 28 24 27 L28 24 L36 24 L40 27 C44 28 48 30 48 34 L48 38 C48 39.1 47.1 40 46 40 L44 40 A4 4 0 0 1 36 40 L28 40 A4 4 0 0 1 20 40 L18 40 C16.9 40 16 39.1 16 38 Z"
+    fill="white"/>
+  <!-- Windshield -->
+  <path d="M27 27 L29 24 L35 24 L37 27 Z" fill="#0F2B5B"/>
+  <!-- Left wheel -->
+  <circle cx="24" cy="40" r="3.5" fill="#0F2B5B" stroke="white" stroke-width="1.5"/>
+  <!-- Right wheel -->
+  <circle cx="40" cy="40" r="3.5" fill="#0F2B5B" stroke="white" stroke-width="1.5"/>
+</svg>

--- a/demos/otokoccomtr/index.html
+++ b/demos/otokoccomtr/index.html
@@ -1,0 +1,857 @@
+<!doctype html>
+<html lang="tr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="data:," />
+    <title>Gengage Dev — otokoccomtr</title>
+
+    <style>
+      /* ── Brand tokens ── */
+      :root {
+        --brand-primary: #0f2b5b;
+        --brand-primary-hover: #1a3d7a;
+        --brand-accent: #f97d1a;
+        --brand-bg: #f4f6f9;
+        --brand-surface: #ffffff;
+        --brand-text: #1a1a2e;
+        --brand-muted: #5a6475;
+        --brand-border: #dde3ec;
+        --brand-font: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      }
+
+      *,
+      *::before,
+      *::after { box-sizing: border-box; }
+
+      body {
+        margin: 0;
+        background: var(--brand-bg);
+        color: var(--brand-text);
+        font-family: var(--brand-font);
+        line-height: 1.4;
+      }
+
+      /* ── Dev header ── */
+      .dev-header {
+        position: sticky;
+        top: 0;
+        z-index: 999;
+        background: #0a1628;
+        color: #cbd5e1;
+        border-bottom: 1px solid #1e2d45;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+        padding: 10px 16px;
+      }
+
+      .dev-header__title {
+        color: #f8fafc;
+        font-size: 13px;
+        font-weight: 700;
+        margin: 0 0 5px;
+        letter-spacing: 0.02em;
+      }
+
+      .dev-header__row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px 18px;
+      }
+
+      .dev-header__item strong { color: #94a3b8; font-weight: 400; }
+      .dev-header__item span { color: #e2e8f0; }
+
+      /* ── Header / Nav ── */
+      .host-header {
+        background: var(--brand-primary);
+        color: #fff;
+        padding: 0 24px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        min-height: 64px;
+      }
+
+      .host-logo {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        font-size: 20px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        white-space: nowrap;
+      }
+
+      .host-logo-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: var(--brand-accent);
+      }
+
+      .host-nav {
+        display: flex;
+        gap: 20px;
+        font-size: 13px;
+        font-weight: 500;
+        color: rgba(255, 255, 255, 0.82);
+        white-space: nowrap;
+        overflow-x: auto;
+        scrollbar-width: none;
+      }
+
+      .host-nav::-webkit-scrollbar { display: none; }
+
+      .host-nav span {
+        cursor: pointer;
+        padding: 4px 0;
+        transition: color 0.15s;
+      }
+
+      .host-nav span:hover { color: #fff; }
+
+      .host-nav span.active {
+        color: #fff;
+        border-bottom: 2px solid var(--brand-accent);
+      }
+
+      .host-header-cta {
+        display: flex;
+        gap: 10px;
+        flex-shrink: 0;
+      }
+
+      .btn {
+        border: none;
+        border-radius: 6px;
+        font-size: 13px;
+        font-weight: 600;
+        padding: 9px 16px;
+        cursor: pointer;
+        transition: background 0.15s, transform 0.1s;
+      }
+
+      .btn--ghost {
+        background: rgba(255, 255, 255, 0.1);
+        color: #fff;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+      }
+
+      .btn--ghost:hover { background: rgba(255, 255, 255, 0.18); }
+
+      .btn--accent {
+        background: var(--brand-accent);
+        color: #fff;
+      }
+
+      .btn--accent:hover {
+        background: #e66f15;
+        transform: translateY(-1px);
+      }
+
+      /* ── Hero banner ── */
+      .host-hero {
+        background: linear-gradient(135deg, #0f2b5b 0%, #1a3d7a 55%, #0f2b5b 100%);
+        color: #fff;
+        padding: 40px 24px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+        flex-wrap: wrap;
+      }
+
+      .hero-text h1 {
+        margin: 0 0 10px;
+        font-size: clamp(22px, 3vw, 36px);
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        line-height: 1.15;
+      }
+
+      .hero-text p {
+        margin: 0 0 20px;
+        font-size: 15px;
+        color: rgba(255, 255, 255, 0.78);
+        max-width: 460px;
+        line-height: 1.55;
+      }
+
+      .hero-badges {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      .hero-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        background: rgba(255, 255, 255, 0.1);
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        border-radius: 6px;
+        padding: 5px 10px;
+        font-size: 12px;
+        font-weight: 600;
+        color: rgba(255, 255, 255, 0.9);
+      }
+
+      .hero-visual {
+        font-size: clamp(60px, 8vw, 100px);
+        line-height: 1;
+        user-select: none;
+      }
+
+      /* ── Shell ── */
+      .host-shell {
+        max-width: 1280px;
+        margin: 0 auto;
+        padding: 24px 20px 120px;
+      }
+
+      .section-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 18px;
+      }
+
+      .section-title {
+        margin: 0;
+        font-size: clamp(18px, 2.2vw, 24px);
+        font-weight: 700;
+        color: var(--brand-text);
+        letter-spacing: -0.01em;
+      }
+
+      .section-link {
+        font-size: 13px;
+        color: var(--brand-primary);
+        font-weight: 600;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+
+      /* ── Brand filter row ── */
+      .brand-filters {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-bottom: 22px;
+      }
+
+      .brand-pill {
+        border: 1.5px solid var(--brand-border);
+        border-radius: 999px;
+        padding: 6px 14px;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--brand-muted);
+        background: var(--brand-surface);
+        cursor: pointer;
+        transition: all 0.15s;
+      }
+
+      .brand-pill:hover {
+        border-color: var(--brand-primary);
+        color: var(--brand-primary);
+      }
+
+      .brand-pill.active {
+        background: var(--brand-primary);
+        border-color: var(--brand-primary);
+        color: #fff;
+      }
+
+      /* ── Vehicle grid ── */
+      .vehicle-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        gap: 20px;
+      }
+
+      .vehicle-card {
+        background: var(--brand-surface);
+        border: 1px solid var(--brand-border);
+        border-radius: 12px;
+        overflow: hidden;
+        transition: box-shadow 0.2s, transform 0.2s;
+        cursor: pointer;
+      }
+
+      .vehicle-card:hover {
+        box-shadow: 0 8px 24px rgba(15, 43, 91, 0.14);
+        transform: translateY(-2px);
+      }
+
+      .vehicle-card-image {
+        height: 160px;
+        background: linear-gradient(145deg,
+          color-mix(in srgb, var(--brand-primary) 8%, white),
+          color-mix(in srgb, var(--brand-primary) 4%, white));
+        display: grid;
+        place-items: center;
+        font-size: 48px;
+      }
+
+      .vehicle-card-body {
+        padding: 14px 16px 16px;
+      }
+
+      .vehicle-brand-badge {
+        display: inline-block;
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        color: var(--brand-primary);
+        margin-bottom: 6px;
+      }
+
+      .vehicle-name {
+        margin: 0 0 6px;
+        font-size: 15px;
+        font-weight: 700;
+        line-height: 1.3;
+        color: var(--brand-text);
+      }
+
+      .vehicle-specs {
+        display: flex;
+        gap: 12px;
+        flex-wrap: wrap;
+        font-size: 12px;
+        color: var(--brand-muted);
+        margin-bottom: 12px;
+      }
+
+      .vehicle-spec-item {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .vehicle-card-actions {
+        display: flex;
+        gap: 8px;
+      }
+
+      .vehicle-btn {
+        flex: 1;
+        border: none;
+        border-radius: 6px;
+        padding: 8px 0;
+        font-size: 12px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: background 0.15s;
+      }
+
+      .vehicle-btn--primary {
+        background: var(--brand-primary);
+        color: #fff;
+      }
+
+      .vehicle-btn--primary:hover { background: var(--brand-primary-hover); }
+
+      .vehicle-btn--ghost {
+        background: color-mix(in srgb, var(--brand-primary) 8%, white);
+        color: var(--brand-primary);
+        border: 1px solid color-mix(in srgb, var(--brand-primary) 22%, white);
+      }
+
+      .vehicle-btn--ghost:hover {
+        background: color-mix(in srgb, var(--brand-primary) 14%, white);
+      }
+
+      /* ── Info bar ── */
+      .info-bar {
+        display: flex;
+        gap: 0;
+        border: 1px solid var(--brand-border);
+        border-radius: 12px;
+        background: var(--brand-surface);
+        overflow: hidden;
+        margin-top: 28px;
+      }
+
+      .info-bar-item {
+        flex: 1;
+        padding: 18px 20px;
+        text-align: center;
+        border-right: 1px solid var(--brand-border);
+      }
+
+      .info-bar-item:last-child { border-right: none; }
+
+      .info-bar-value {
+        font-size: 24px;
+        font-weight: 800;
+        color: var(--brand-primary);
+        display: block;
+        margin-bottom: 4px;
+      }
+
+      .info-bar-label {
+        font-size: 12px;
+        color: var(--brand-muted);
+        font-weight: 500;
+      }
+
+      /* ── Voice chat CSS (from robot-engine-lean/voiceChat.css) ── */
+      .glov-voice-chat-container {
+        width: auto;
+        min-width: 300px;
+        max-width: 400px;
+        height: 70px;
+        position: fixed;
+        bottom: 100px;
+        right: 25px;
+        z-index: 1000;
+        display: flex;
+        flex-direction: column;
+        align-items: stretch;
+        justify-content: flex-start;
+        border-radius: 16px;
+        overflow: visible;
+        background: transparent;
+      }
+
+      .glov-voice-chat-container.glov-voice-chat-expanded { height: 620px; max-width: 420px; }
+
+      .glov-voice-chat-container.glov-voice-chat-desktop-launcher {
+        min-width: auto; max-width: 260px; height: 52px;
+      }
+
+      .glov-voice-chat-container-inner {
+        width: 100%;
+        height: 70px;
+        background: linear-gradient(180deg, #2e2e2e 0%, #1e1e1e 100%);
+        border: 1px solid rgba(255,255,255,0.08);
+        border-radius: 16px;
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        justify-content: center;
+        padding: 8px 14px;
+        gap: 10px;
+        flex-shrink: 0;
+        box-shadow: 0 16px 30px rgba(0,0,0,0.24);
+        transition: opacity 0.16s ease, transform 0.16s ease, visibility 0s linear 0.16s;
+        position: relative;
+        z-index: 2;
+      }
+
+      .glov-voice-chat-container.glov-voice-chat-desktop-launcher .glov-voice-chat-container-inner {
+        height: 52px; padding: 5px 10px;
+      }
+
+      .glov-voice-chat-container.glov-voice-chat-panel-open .glov-voice-chat-container-inner {
+        opacity: 0; transform: scale(0.98); pointer-events: none; visibility: hidden;
+      }
+
+      .glov-voice-chat-call-button {
+        display: flex; align-items: center; justify-content: center;
+        gap: 8px; padding: 8px 18px;
+        border: none; border-radius: 9999px;
+        background-color: #f97d1a; color: #fff;
+        font-size: 14px; font-weight: 600; cursor: pointer;
+        transition: background-color 0.2s ease, transform 0.1s ease;
+      }
+
+      .glov-voice-chat-call-button:hover { background-color: #e66f15; transform: translateY(-1px); }
+      .glov-voice-chat-call-button:active { transform: translateY(0); background-color: #d46212; }
+
+      .glov-voice-chat-btn-avatar-wrap { position: relative; display: inline-flex; align-items: center; flex-shrink: 0; }
+      .glov-voice-chat-btn-avatar { display: none; }
+      .glov-voice-chat-btn-live-dot { display: none; }
+      .glov-voice-chat-btn-phone-icon { flex-shrink: 0; }
+
+      .glov-voice-chat-container.glov-voice-chat-desktop-launcher .glov-voice-chat-btn-avatar {
+        display: block; width: 32px; height: 32px; border-radius: 50%; object-fit: cover;
+        border: 2px solid rgba(255,255,255,0.35);
+      }
+      .glov-voice-chat-container.glov-voice-chat-desktop-launcher .glov-voice-chat-btn-live-dot {
+        display: block; position: absolute; bottom: 1px; right: 1px;
+        width: 10px; height: 10px; border-radius: 50%;
+        background-color: #4ade80; border: 2px solid #f97d1a;
+        animation: glov-live-pulse 2s ease-in-out infinite;
+      }
+      .glov-voice-chat-container.glov-voice-chat-desktop-launcher .glov-voice-chat-btn-phone-icon { display: none; }
+      .glov-voice-chat-container:not(.glov-voice-chat-desktop-launcher) .glov-voice-chat-btn-avatar {
+        display: block; width: 26px; height: 26px; border-radius: 50%; object-fit: cover;
+        border: 2px solid rgba(255,255,255,0.35);
+      }
+      .glov-voice-chat-container:not(.glov-voice-chat-desktop-launcher) .glov-voice-chat-btn-live-dot {
+        display: block; position: absolute; bottom: 0; right: 0;
+        width: 9px; height: 9px; border-radius: 50%;
+        background-color: #4ade80; border: 2px solid #f97d1a;
+      }
+      .glov-voice-chat-container:not(.glov-voice-chat-desktop-launcher) .glov-voice-chat-btn-phone-icon { display: none; }
+
+      .glov-voice-chat-panel {
+        position: absolute; inset: 0;
+        background:
+          radial-gradient(circle at top, rgba(249,125,26,0.16), transparent 40%),
+          linear-gradient(180deg, #131313 0%, #1b1b1b 100%);
+        border: 1px solid rgba(255,255,255,0.08);
+        border-radius: 24px;
+        box-shadow: 0 22px 48px rgba(0,0,0,0.34);
+        transition: transform 0.18s ease, opacity 0.18s ease;
+        transform: translateY(12px) scale(0.985);
+        opacity: 0; pointer-events: none; overflow: hidden;
+      }
+
+      .glov-voice-chat-panel.active { transform: translateY(0) scale(1); opacity: 1; pointer-events: auto; }
+
+      .glov-voice-chat-panel-hit-layer { display: none; }
+
+      .glov-voice-chat-panel-content {
+        width: 100%; height: 100%;
+        display: grid; grid-template-rows: auto minmax(0,1fr) auto auto;
+        gap: 16px; padding: 22px; box-sizing: border-box; color: #fff;
+      }
+
+      .glov-voice-chat-panel-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+      .glov-voice-chat-panel-kicker { font-size: 12px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: rgba(255,255,255,0.72); }
+      .glov-voice-chat-panel-actions { display: flex; align-items: center; gap: 10px; }
+
+      .glov-voice-chat-icon-button {
+        width: 38px; height: 38px; border-radius: 12px;
+        border: 1px solid rgba(255,255,255,0.1); background: rgba(255,255,255,0.06);
+        color: #fff; cursor: pointer; display: inline-flex; align-items: center; justify-content: center;
+        transition: background 0.2s;
+      }
+      .glov-voice-chat-icon-button:hover { background: rgba(255,255,255,0.12); }
+
+      .glov-voice-chat-hero { display: flex; align-items: stretch; }
+
+      .glov-voice-chat-orb-shell {
+        display: flex; align-items: center; justify-content: center;
+        width: 100%; min-height: 100%; padding: 24px 20px 22px;
+        border-radius: 24px;
+        background: radial-gradient(circle at top, rgba(255,255,255,0.06), transparent 55%), rgba(255,255,255,0.04);
+        border: 1px solid rgba(255,255,255,0.06);
+      }
+
+      .glov-voice-chat-orb-container {
+        display: flex; flex-direction: column; align-items: center; justify-content: center;
+        width: min(100%, 300px); gap: 16px; text-align: center;
+      }
+
+      .glov-voice-chat-status-row { display: grid; gap: 10px; justify-items: center; }
+
+      .glov-voice-chat-status-badge {
+        display: inline-flex; align-items: center; justify-content: center;
+        width: fit-content; min-height: 30px; padding: 0 12px; border-radius: 999px;
+        background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.1);
+        font-size: 12px; font-weight: 700; letter-spacing: 0.03em; text-transform: uppercase;
+      }
+
+      .glov-voice-chat-status-copy { font-size: 15px; line-height: 1.4; color: rgba(255,255,255,0.9); text-align: center; }
+
+      .orb {
+        width: 118px; height: 118px; border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, #ffb074, #f97d1a, #d46212);
+        animation: pulse 1.8s ease-in-out infinite;
+        box-shadow: 0 0 0 12px rgba(249,125,26,0.08), 0 0 28px rgba(249,125,26,0.42);
+        position: relative;
+      }
+
+      .orb::before {
+        content: ''; position: absolute; inset: 0; border-radius: 50%;
+        background: radial-gradient(circle at 30% 30%, rgba(255,255,255,0.34), transparent 68%);
+        pointer-events: none;
+      }
+
+      .glov-voice-chat-panel[data-state='speaking'] .orb {
+        background: radial-gradient(circle at 30% 30%, #ffc372, #f97d1a, #cc5200);
+        box-shadow: 0 0 0 16px rgba(249,125,26,0.12), 0 0 36px rgba(249,125,26,0.48);
+      }
+
+      .glov-voice-chat-panel[data-state='listening'] .orb {
+        background: radial-gradient(circle at 30% 30%, #ffb074, #f97d1a, #b04d12);
+      }
+
+      .glov-voice-chat-panel[data-state='error'] .orb {
+        background: radial-gradient(circle at 30% 30%, #ffaaa5, #ff6b57, #c63c2c);
+      }
+
+      @keyframes pulse {
+        0%, 100% { transform: scale(1); opacity: 1; }
+        50% { transform: scale(1.08); opacity: 0.86; }
+      }
+
+      @keyframes glov-live-pulse {
+        0%, 100% { box-shadow: 0 0 0 1px rgba(74,222,128,0.25); }
+        50% { box-shadow: 0 0 0 4px rgba(74,222,128,0.15); }
+      }
+
+      .glov-voice-chat-title { font-size: 21px; font-weight: 700; line-height: 1.15; color: #fff; text-align: center; }
+      .glov-voice-chat-live-copy { font-size: 13px; line-height: 1.45; color: rgba(255,255,255,0.72); max-width: 250px; }
+
+      .glov-audio-waveform { width: min(100%, 220px); height: 44px; display: block; }
+
+      .glov-voice-chat-security-notice {
+        display: flex; align-items: flex-start; gap: 10px;
+        padding: 12px 14px; border-radius: 16px;
+        background: rgba(249,125,26,0.12); border: 1px solid rgba(249,125,26,0.18);
+        color: rgba(255,255,255,0.86);
+      }
+
+      .glov-security-icon { flex-shrink: 0; color: #f8b270; margin-top: 1px; }
+      .glov-voice-chat-security-notice p { margin: 0; font-size: 13px; line-height: 1.45; }
+
+      .glov-voice-chat-panel-controls { display: flex; }
+
+      .glov-voice-chat-panel-button {
+        min-height: 48px; padding: 0 18px; border-radius: 9999px; border: none;
+        color: #fff; font-size: 14px; font-weight: 700; cursor: pointer;
+        transition: background 0.2s, transform 0.1s;
+      }
+
+      .glov-voice-chat-panel-button-primary { background: #f97d1a; width: 100%; }
+      .glov-voice-chat-panel-button-primary:hover { background: #e66f15; }
+
+      html.glov-voice-fullscreen-open,
+      body.glov-voice-fullscreen-open { overflow: hidden !important; }
+
+      @media (max-width: 768px) {
+        .glov-voice-chat-container {
+          min-width: auto; max-width: min(100vw - 24px, 360px);
+          width: auto; height: 52px;
+          right: max(12px, env(safe-area-inset-right, 0px)) !important;
+          bottom: max(80px, calc(80px + env(safe-area-inset-bottom, 0px))) !important;
+        }
+
+        .glov-voice-chat-panel.glov-voice-chat-fullscreen {
+          position: fixed !important; inset: 0 !important;
+          width: 100% !important; height: 100dvh !important;
+          z-index: 2147483000 !important; border-radius: 0 !important;
+          border: none !important;
+        }
+
+        .glov-voice-chat-panel.glov-voice-chat-fullscreen .glov-voice-chat-panel-content {
+          position: relative; z-index: 1; flex: 1 1 auto;
+          padding: calc(12px + env(safe-area-inset-top, 0px))
+            max(12px, env(safe-area-inset-right, 0px))
+            calc(12px + env(safe-area-inset-bottom, 0px))
+            max(12px, env(safe-area-inset-left, 0px));
+          display: flex; flex-direction: column; gap: 10px;
+          overflow-y: auto;
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <!-- Dev header -->
+    <div class="dev-header">
+      <p class="dev-header__title">Gengage Dev — otokoccomtr</p>
+      <div class="dev-header__row">
+        <span class="dev-header__item"><strong>account:</strong> <span>otokoccomtr</span></span>
+        <span class="dev-header__item"><strong>backend:</strong> <span id="dev-backend">—</span></span>
+        <span class="dev-header__item"><strong>session:</strong> <span id="dev-session">—</span></span>
+      </div>
+    </div>
+
+    <!-- Dealer header -->
+    <header class="host-header">
+      <div class="host-logo">
+        <span class="host-logo-dot"></span>
+        <span>Otokoç Otomotiv</span>
+      </div>
+      <nav class="host-nav" aria-label="Ana menü">
+        <span class="active">Araçlar</span>
+        <span>Ford</span>
+        <span>Volvo</span>
+        <span>Fiat</span>
+        <span>Jeep</span>
+        <span>Alfa Romeo</span>
+        <span>Maserati</span>
+        <span>Servis</span>
+        <span>İletişim</span>
+      </nav>
+      <div class="host-header-cta">
+        <button class="btn btn--ghost" type="button">Servis Randevusu</button>
+        <button class="btn btn--accent" type="button">Test Sürüşü</button>
+      </div>
+    </header>
+
+    <!-- Hero -->
+    <section class="host-hero">
+      <div class="hero-text">
+        <h1>Türkiye'nin En Büyük<br>Yetkili Otomobil Bayisi</h1>
+        <p>
+          Ford, Volvo, Fiat, Jeep, Alfa Romeo ve Maserati araçlarını keşfedin.
+          AI asistanımız araç seçiminde ve servis rezervasyonunda size yardımcı olur.
+        </p>
+        <div class="hero-badges">
+          <span class="hero-badge">🏆 95+ Araç Modeli</span>
+          <span class="hero-badge">📍 Türkiye Geneli Bayi</span>
+          <span class="hero-badge">⚡ 7 Marka</span>
+        </div>
+      </div>
+      <div class="hero-visual" aria-hidden="true">🚗</div>
+    </section>
+
+    <!-- Main content -->
+    <main class="host-shell">
+
+      <!-- Brand filters -->
+      <div class="brand-filters" id="brand-filters" role="group" aria-label="Marka filtresi">
+        <button class="brand-pill active" data-brand="">Tümü</button>
+        <button class="brand-pill" data-brand="Ford">Ford</button>
+        <button class="brand-pill" data-brand="Volvo">Volvo</button>
+        <button class="brand-pill" data-brand="Fiat">Fiat</button>
+        <button class="brand-pill" data-brand="Jeep">Jeep</button>
+        <button class="brand-pill" data-brand="Alfa Romeo">Alfa Romeo</button>
+        <button class="brand-pill" data-brand="Maserati">Maserati</button>
+      </div>
+
+      <!-- Vehicle grid -->
+      <div class="section-header">
+        <h2 class="section-title">Öne Çıkan Araçlar</h2>
+        <span class="section-link">Tüm araçları gör →</span>
+      </div>
+
+      <div class="vehicle-grid" id="vehicle-grid">
+        <!-- Populated by JS below -->
+      </div>
+
+      <!-- Stats bar -->
+      <div class="info-bar">
+        <div class="info-bar-item">
+          <span class="info-bar-value">95+</span>
+          <span class="info-bar-label">Araç Modeli</span>
+        </div>
+        <div class="info-bar-item">
+          <span class="info-bar-value">6</span>
+          <span class="info-bar-label">Marka</span>
+        </div>
+        <div class="info-bar-item">
+          <span class="info-bar-value">50+</span>
+          <span class="info-bar-label">Yetki Belgeli Bayi</span>
+        </div>
+        <div class="info-bar-item">
+          <span class="info-bar-value">24/7</span>
+          <span class="info-bar-label">AI Asistan</span>
+        </div>
+      </div>
+
+    </main>
+
+    <script type="module">
+      import { initOverlayWidgets } from '@gengage/assistant-fe';
+      import { createVoiceLauncher } from './voice-launcher.ts';
+
+      // ── Config from URL params ──────────────────────────────────────────
+      const params = new URLSearchParams(location.search);
+      const middlewareUrl = params.get('middlewareUrl') ?? 'http://localhost:5990/api';
+
+      document.getElementById('dev-backend').textContent = middlewareUrl;
+
+      const launcherUrl = new URL('./glov-otokoccomtr-launcher.svg', import.meta.url).href;
+
+      // ── Gengage chat widget ─────────────────────────────────────────────
+      const controller = await initOverlayWidgets({
+        accountId: 'otokoccomtr',
+        middlewareUrl,
+        locale: 'tr',
+        theme: {
+          primaryColor: '#0f2b5b',
+          primaryForeground: '#ffffff',
+          backgroundColor: '#ffffff',
+          foregroundColor: '#1a1a2e',
+          borderRadius: '8px',
+          fontFamily: '"Segoe UI", "Helvetica Neue", Arial, sans-serif',
+          fontSize: '14px',
+          zIndex: '900',
+          '--client-primary': '#0f2b5b',
+          '--client-primary-hover': 'color-mix(in srgb, #0f2b5b 88%, white 12%)',
+          '--client-primary-active': 'color-mix(in srgb, #0f2b5b 78%, white 22%)',
+          '--client-primary-subtle': 'color-mix(in srgb, #0f2b5b 10%, white)',
+          '--client-primary-soft': 'color-mix(in srgb, #0f2b5b 18%, white)',
+          '--client-on-primary': '#ffffff',
+          '--client-focus-ring': 'color-mix(in srgb, #0f2b5b 28%, transparent)',
+          '--gengage-chat-launcher-size': '60px',
+        },
+        isDemoWebsite: true,
+        chat: {
+          variant: 'floating',
+          mobileBreakpoint: 768,
+          headerTitle: 'Otokoç AI Asistan',
+          launcherImageUrl: launcherUrl,
+          i18n: {
+            inputPlaceholder: 'Araç sor, test sürüşü al, servis randevusu...',
+            poweredBy: 'Otokoç AI',
+          },
+        },
+        onProductNavigate: (url, _sku, sid) => {
+          if (sid) controller.chat?.saveSession(sid, _sku ?? '');
+          window.location.href = url;
+        },
+      });
+
+      document.getElementById('dev-session').textContent =
+        controller.session.sessionId.slice(0, 12) + '…';
+
+      // ── ElevenLabs voice launcher ───────────────────────────────────────
+      const voiceLauncher = createVoiceLauncher(middlewareUrl);
+      document.body.appendChild(voiceLauncher);
+
+      // ── Vehicle demo grid ───────────────────────────────────────────────
+      const VEHICLES = [
+        { brand: 'Ford', emoji: '🚙', name: 'Ford Focus 1.5 EcoBoost Titanium', specs: ['1.5L Benzin', '182 hp', 'Otomatik'] },
+        { brand: 'Ford', emoji: '🚗', name: 'Ford Puma 1.0 EcoBoost ST-Line X', specs: ['1.0L Benzin', '125 hp', 'Manuel'] },
+        { brand: 'Volvo', emoji: '🚘', name: 'Volvo XC60 B5 AWD R-Design', specs: ['2.0L Hybrid', '250 hp', 'Otomatik'] },
+        { brand: 'Volvo', emoji: '🚗', name: 'Volvo V60 B4 Inscription', specs: ['2.0L Benzin', '197 hp', 'Otomatik'] },
+        { brand: 'Jeep', emoji: '🛻', name: 'Jeep Compass 1.3 T270 Limited', specs: ['1.3L Benzin', '150 hp', 'Otomatik'] },
+        { brand: 'Fiat', emoji: '🚗', name: 'Fiat Egea 1.4 Fire Easy', specs: ['1.4L Benzin', '95 hp', 'Manuel'] },
+        { brand: 'Alfa Romeo', emoji: '🏎️', name: 'Alfa Romeo Stelvio 2.0T Q4 Sprint', specs: ['2.0L Benzin', '280 hp', 'Otomatik'] },
+        { brand: 'Maserati', emoji: '🏎️', name: 'Maserati Ghibli 2.0 Hybrid GT', specs: ['2.0L Hybrid', '330 hp', 'Otomatik'] },
+      ];
+
+      const grid = document.getElementById('vehicle-grid');
+      let activeBrand = '';
+
+      function renderGrid() {
+        const filtered = activeBrand
+          ? VEHICLES.filter(v => v.brand === activeBrand)
+          : VEHICLES;
+
+        grid.innerHTML = filtered.map(v => `
+          <article class="vehicle-card" data-brand="${v.brand}">
+            <div class="vehicle-card-image">${v.emoji}</div>
+            <div class="vehicle-card-body">
+              <span class="vehicle-brand-badge">${v.brand}</span>
+              <h3 class="vehicle-name">${v.name}</h3>
+              <div class="vehicle-specs">
+                ${v.specs.map(s => `<span class="vehicle-spec-item">• ${s}</span>`).join('')}
+              </div>
+              <div class="vehicle-card-actions">
+                <button class="vehicle-btn vehicle-btn--primary" type="button">Test Sürüşü</button>
+                <button class="vehicle-btn vehicle-btn--ghost" type="button">Detaylar</button>
+              </div>
+            </div>
+          </article>
+        `).join('');
+      }
+
+      renderGrid();
+
+      // Brand filter clicks
+      document.getElementById('brand-filters').addEventListener('click', e => {
+        const pill = e.target.closest('[data-brand]');
+        if (!pill) return;
+        document.querySelectorAll('.brand-pill').forEach(p => p.classList.remove('active'));
+        pill.classList.add('active');
+        activeBrand = pill.dataset.brand;
+        renderGrid();
+      });
+    </script>
+  </body>
+</html>

--- a/demos/otokoccomtr/index.html
+++ b/demos/otokoccomtr/index.html
@@ -654,6 +654,7 @@
       <div class="dev-header__row">
         <span class="dev-header__item"><strong>account:</strong> <span>otokoccomtr</span></span>
         <span class="dev-header__item"><strong>backend:</strong> <span id="dev-backend">—</span></span>
+        <span class="dev-header__item"><strong>sku:</strong> <span id="dev-sku">—</span></span>
         <span class="dev-header__item"><strong>session:</strong> <span id="dev-session">—</span></span>
       </div>
     </div>
@@ -701,6 +702,12 @@
     <!-- Main content -->
     <main class="host-shell">
 
+      <!-- PDP view (populated by JS when ?sku= is present) -->
+      <div id="pdp-section" style="display:none;"></div>
+
+      <!-- Catalog view -->
+      <div id="catalog-section">
+
       <!-- Brand filters -->
       <div class="brand-filters" id="brand-filters" role="group" aria-label="Marka filtresi">
         <button class="brand-pill active" data-brand="">Tümü</button>
@@ -742,6 +749,7 @@
         </div>
       </div>
 
+      </div><!-- /catalog-section -->
     </main>
 
     <script type="module">
@@ -751,8 +759,10 @@
       // ── Config from URL params ──────────────────────────────────────────
       const params = new URLSearchParams(location.search);
       const middlewareUrl = params.get('middlewareUrl') ?? 'http://localhost:5990/api';
+      const sku = params.get('sku') ?? undefined;
 
       document.getElementById('dev-backend').textContent = middlewareUrl;
+      document.getElementById('dev-sku').textContent = sku ?? '—';
 
       const launcherUrl = new URL('./glov-otokoccomtr-launcher.svg', import.meta.url).href;
 
@@ -761,6 +771,8 @@
         accountId: 'otokoccomtr',
         middlewareUrl,
         locale: 'tr',
+        sku,
+        pageContext: { pageType: sku ? 'pdp' : 'other', sku },
         theme: {
           primaryColor: '#0f2b5b',
           primaryForeground: '#ffffff',
@@ -803,20 +815,58 @@
       const voiceLauncher = createVoiceLauncher(middlewareUrl);
       document.body.appendChild(voiceLauncher);
 
-      // ── Vehicle demo grid ───────────────────────────────────────────────
+      // ── Vehicle demo grid (SKUs from backend catalog.json) ─────────────
       const VEHICLES = [
-        { brand: 'Ford', emoji: '🚙', name: 'Ford Focus 1.5 EcoBoost Titanium', specs: ['1.5L Benzin', '182 hp', 'Otomatik'] },
-        { brand: 'Ford', emoji: '🚗', name: 'Ford Puma 1.0 EcoBoost ST-Line X', specs: ['1.0L Benzin', '125 hp', 'Manuel'] },
-        { brand: 'Volvo', emoji: '🚘', name: 'Volvo XC60 B5 AWD R-Design', specs: ['2.0L Hybrid', '250 hp', 'Otomatik'] },
-        { brand: 'Volvo', emoji: '🚗', name: 'Volvo V60 B4 Inscription', specs: ['2.0L Benzin', '197 hp', 'Otomatik'] },
-        { brand: 'Jeep', emoji: '🛻', name: 'Jeep Compass 1.3 T270 Limited', specs: ['1.3L Benzin', '150 hp', 'Otomatik'] },
-        { brand: 'Fiat', emoji: '🚗', name: 'Fiat Egea 1.4 Fire Easy', specs: ['1.4L Benzin', '95 hp', 'Manuel'] },
-        { brand: 'Alfa Romeo', emoji: '🏎️', name: 'Alfa Romeo Stelvio 2.0T Q4 Sprint', specs: ['2.0L Benzin', '280 hp', 'Otomatik'] },
-        { brand: 'Maserati', emoji: '🏎️', name: 'Maserati Ghibli 2.0 Hybrid GT', specs: ['2.0L Hybrid', '330 hp', 'Otomatik'] },
+        { sku: '108349333', brand: 'Ford', emoji: '🚙', name: 'Ford Focus 1.5 EcoBoost Titanium', specs: ['1.5L Benzin', '182 hp', 'Otomatik'] },
+        { sku: '105216848', brand: 'Ford', emoji: '🚗', name: 'Ford Puma ST-Line', specs: ['1.0L Benzin', '125 hp', 'Manuel'] },
+        { sku: '109769470', brand: 'Volvo', emoji: '🚘', name: 'Volvo XC60 Plus Dark', specs: ['2.0L Hybrid', '250 hp', 'Otomatik'] },
+        { sku: '114430160', brand: 'Volvo', emoji: '🚗', name: 'Volvo XC60 Plus Bright', specs: ['2.0L Benzin', '197 hp', 'Otomatik'] },
+        { sku: '100517803', brand: 'Jeep', emoji: '🛻', name: 'Jeep Compass Limited', specs: ['1.3L Benzin', '150 hp', 'Otomatik'] },
+        { sku: '102796531', brand: 'Fiat', emoji: '🚗', name: 'Fiat 500 Dolcevita', specs: ['1.0L Benzin', '70 hp', 'Manuel'] },
+        { sku: '100281185', brand: 'Alfa Romeo', emoji: '🏎️', name: 'Alfa Romeo Stelvio Veloce', specs: ['2.0L Benzin', '280 hp', 'Otomatik'] },
+        { sku: '105053261', brand: 'Maserati', emoji: '🏎️', name: 'Maserati Ghibli 2.0 Hybrid GT', specs: ['2.0L Hybrid', '330 hp', 'Otomatik'] },
       ];
 
       const grid = document.getElementById('vehicle-grid');
+      const pdpSection = document.getElementById('pdp-section');
+      const catalogSection = document.getElementById('catalog-section');
       let activeBrand = '';
+
+      // ── PDP view (when ?sku= is present) ────────────────────────────────
+      const activeVehicle = sku ? VEHICLES.find(v => v.sku === sku) : undefined;
+      if (sku) {
+        catalogSection.style.display = 'none';
+        const v = activeVehicle ?? { brand: '—', emoji: '🚗', name: `Araç SKU: ${sku}`, specs: [] };
+        pdpSection.innerHTML = `
+          <a href="?middlewareUrl=${encodeURIComponent(middlewareUrl)}" style="display:inline-block;margin-bottom:16px;color:var(--brand-primary);font-size:13px;font-weight:600;text-decoration:none;">← Tüm Araçlar</a>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:32px;align-items:start;">
+            <div style="background:linear-gradient(145deg,#eef2f8,#f6f8fc);border-radius:16px;height:320px;display:grid;place-items:center;font-size:100px;">${v.emoji}</div>
+            <div>
+              <span class="vehicle-brand-badge" style="font-size:13px;">${v.brand}</span>
+              <h1 style="margin:6px 0 12px;font-size:26px;font-weight:800;color:var(--brand-text);">${v.name}</h1>
+              <div style="display:flex;gap:16px;flex-wrap:wrap;font-size:13px;color:var(--brand-muted);margin-bottom:20px;">
+                ${v.specs.map(s => `<span>• ${s}</span>`).join('')}
+              </div>
+              <p style="font-size:13px;color:var(--brand-muted);margin-bottom:6px;">SKU: <strong>${sku}</strong></p>
+              <div style="display:flex;gap:10px;margin-top:24px;">
+                <button class="btn btn--accent" type="button" style="padding:12px 28px;">Test Sürüşü Randevusu</button>
+                <button class="btn btn--ghost" type="button" style="padding:12px 28px;color:var(--brand-primary);border-color:var(--brand-primary);">Bayileri Gör</button>
+              </div>
+              <p style="margin-top:20px;font-size:12px;color:var(--brand-muted);">
+                Sağ alttaki <strong>Otokoç AI</strong> butonuna tıklayarak bu araç hakkında sorular sorabilirsiniz.
+              </p>
+            </div>
+          </div>
+        `;
+        pdpSection.style.display = 'block';
+      }
+
+      // ── Catalog grid ────────────────────────────────────────────────────
+      function navigateToSku(vehicleSku) {
+        const url = new URL(location.href);
+        url.searchParams.set('sku', vehicleSku);
+        location.href = url.toString();
+      }
 
       function renderGrid() {
         const filtered = activeBrand
@@ -824,7 +874,7 @@
           : VEHICLES;
 
         grid.innerHTML = filtered.map(v => `
-          <article class="vehicle-card" data-brand="${v.brand}">
+          <article class="vehicle-card" data-brand="${v.brand}" data-sku="${v.sku}">
             <div class="vehicle-card-image">${v.emoji}</div>
             <div class="vehicle-card-body">
               <span class="vehicle-brand-badge">${v.brand}</span>
@@ -834,14 +884,17 @@
               </div>
               <div class="vehicle-card-actions">
                 <button class="vehicle-btn vehicle-btn--primary" type="button">Test Sürüşü</button>
-                <button class="vehicle-btn vehicle-btn--ghost" type="button">Detaylar</button>
+                <button class="vehicle-btn vehicle-btn--ghost" type="button" onclick="window.__navigateToSku('${v.sku}')">Detaylar</button>
               </div>
             </div>
           </article>
         `).join('');
       }
 
-      renderGrid();
+      // Expose navigation for inline onclick handlers
+      window.__navigateToSku = navigateToSku;
+
+      if (!sku) renderGrid();
 
       // Brand filter clicks
       document.getElementById('brand-filters').addEventListener('click', e => {

--- a/demos/otokoccomtr/index.html
+++ b/demos/otokoccomtr/index.html
@@ -408,8 +408,8 @@
         max-width: 400px;
         height: 70px;
         position: fixed;
-        bottom: 100px;
-        right: 25px;
+        bottom: 24px;
+        left: 24px;
         z-index: 1000;
         display: flex;
         flex-direction: column;
@@ -623,8 +623,9 @@
         .glov-voice-chat-container {
           min-width: auto; max-width: min(100vw - 24px, 360px);
           width: auto; height: 52px;
-          right: max(12px, env(safe-area-inset-right, 0px)) !important;
-          bottom: max(80px, calc(80px + env(safe-area-inset-bottom, 0px))) !important;
+          left: max(12px, env(safe-area-inset-left, 0px)) !important;
+          right: auto !important;
+          bottom: max(24px, calc(24px + env(safe-area-inset-bottom, 0px))) !important;
         }
 
         .glov-voice-chat-panel.glov-voice-chat-fullscreen {

--- a/demos/otokoccomtr/voice-launcher.ts
+++ b/demos/otokoccomtr/voice-launcher.ts
@@ -1,0 +1,352 @@
+/**
+ * Otokoç AI Voice Launcher
+ *
+ * Floating voice assistant launcher for the otokoccomtr demo.
+ * Adapted from robot-engine-lean/voiceAssistantLauncher.ts — simplified to core
+ * session flow (no OTP/SMS handoff, no UA sniffing).
+ *
+ * UI is injected as a fixed-position element on document.body.
+ * CSS comes from the <style> block in index.html.
+ */
+
+import { Conversation } from '@elevenlabs/client';
+
+type VoicePanelState = 'idle' | 'connecting' | 'speaking' | 'listening' | 'error';
+
+const STATE_LABELS: Record<VoicePanelState, { badge: string; copy: string }> = {
+  idle: { badge: 'Hazır', copy: 'Konuşmaya başlayabilirsiniz.' },
+  connecting: { badge: 'Bağlanıyor', copy: 'Sesli asistan hazırlanıyor.' },
+  speaking: { badge: 'Yanıtlıyor', copy: 'Asistan konuşuyor.' },
+  listening: { badge: 'Sizi Dinliyor', copy: 'Mikrofon açık. Konuşabilirsiniz.' },
+  error: { badge: 'Hata', copy: 'Bağlantı kurulamadı. Tekrar deneyin.' },
+};
+
+function isMobile(): boolean {
+  return window.innerWidth < 768;
+}
+
+export function createVoiceLauncher(middlewareUrl: string): HTMLElement {
+  // ── DOM ─────────────────────────────────────────────────────────────────
+  const container = document.createElement('div');
+  container.className = 'glov-voice-chat-container';
+  container.innerHTML = `
+    <div class="glov-voice-chat-container-inner">
+      <button class="glov-voice-chat-call-button" id="glov-call-agent-btn" type="button">
+        <span class="glov-voice-chat-btn-avatar-wrap">
+          <img class="glov-voice-chat-btn-avatar"
+            src="https://configs.glov.ai/remoteConfig/voice-assistant.jpg" alt="" />
+          <span class="glov-voice-chat-btn-live-dot"></span>
+        </span>
+        <svg class="glov-voice-chat-btn-phone-icon" xmlns="http://www.w3.org/2000/svg"
+          width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1
+            5.19 11a19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72
+            12.84 12.84 0 0 0 .7 2.81 2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27
+            a2 2 0 0 1 2.11-.45 12.84 12.84 0 0 0 2.81.7A2 2 0 0 1 22 16.92z"/>
+        </svg>
+        <span class="glov-voice-chat-call-label">Uzmanla Görüş</span>
+      </button>
+    </div>
+
+    <div class="glov-voice-chat-panel" data-state="idle" style="display:none">
+      <div class="glov-voice-chat-panel-hit-layer" aria-hidden="true"></div>
+      <div class="glov-voice-chat-panel-content">
+
+        <div class="glov-voice-chat-panel-header">
+          <div class="glov-voice-chat-panel-kicker">Otokoç AI Canlı Ses</div>
+          <div class="glov-voice-chat-panel-actions">
+            <button class="glov-voice-chat-icon-button" id="glov-voice-chat-close-icon"
+              type="button" aria-label="Sesli görüşmeyi kapat">
+              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+                viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M18 6 6 18"/><path d="m6 6 12 12"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <div class="glov-voice-chat-hero">
+          <div class="glov-voice-chat-orb-shell">
+            <div class="glov-voice-chat-orb-container">
+              <div class="glov-voice-chat-status-row">
+                <div class="glov-voice-chat-status-badge" id="glov-voice-chat-status-badge">Bağlanıyor</div>
+                <div class="glov-voice-chat-status-copy" id="glov-voice-chat-status-copy">
+                  Sesli asistan hazırlanıyor.
+                </div>
+              </div>
+              <div class="orb"></div>
+              <div class="glov-voice-chat-title">Otokoç Sesli Asistan</div>
+              <div class="glov-voice-chat-live-copy" id="glov-voice-chat-live-copy">
+                Konuşmaya başlayabilirsiniz.
+              </div>
+              <canvas id="glov-audio-waveform" class="glov-audio-waveform"
+                width="220" height="44"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <div class="glov-voice-chat-security-notice">
+          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18"
+            viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+            stroke-linecap="round" stroke-linejoin="round" class="glov-security-icon" aria-hidden="true">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+          </svg>
+          <p>Kalite ve güvenlik için konuşma kayıt altına alınır.</p>
+        </div>
+
+        <div class="glov-voice-chat-panel-controls">
+          <button class="glov-voice-chat-panel-button glov-voice-chat-panel-button-primary"
+            id="glov-voice-chat-end-btn" type="button">
+            Görüşmeyi Bitir
+          </button>
+        </div>
+
+      </div>
+    </div>
+  `;
+
+  // ── Refs ────────────────────────────────────────────────────────────────
+  const callButton = container.querySelector('#glov-call-agent-btn') as HTMLButtonElement;
+  const callLabel = container.querySelector('.glov-voice-chat-call-label') as HTMLElement;
+  const panel = container.querySelector('.glov-voice-chat-panel') as HTMLElement;
+  const innerBar = container.querySelector('.glov-voice-chat-container-inner') as HTMLElement;
+  const closeBtn = container.querySelector('#glov-voice-chat-close-icon') as HTMLButtonElement;
+  const endBtn = container.querySelector('#glov-voice-chat-end-btn') as HTMLButtonElement;
+  const statusBadge = container.querySelector('#glov-voice-chat-status-badge') as HTMLElement;
+  const statusCopy = container.querySelector('#glov-voice-chat-status-copy') as HTMLElement;
+
+  // ── State ───────────────────────────────────────────────────────────────
+  let conversation: Conversation | null = null;
+  let sessionAttemptId = 0;
+  let cachedAgentId: string | null = null;
+  let audioCtx: AudioContext | null = null;
+  let analyserNode: AnalyserNode | null = null;
+  let waveFrameId: number | null = null;
+
+  // ── UI helpers ──────────────────────────────────────────────────────────
+  function setPanelState(state: VoicePanelState) {
+    const { badge, copy } = STATE_LABELS[state];
+    statusBadge.textContent = badge;
+    statusCopy.textContent = copy;
+    panel.setAttribute('data-state', state);
+  }
+
+  function hideInnerBar() {
+    innerBar.style.opacity = '0';
+    innerBar.style.pointerEvents = 'none';
+    innerBar.style.visibility = 'hidden';
+    innerBar.style.transform = 'scale(0.98)';
+  }
+
+  function showInnerBar() {
+    innerBar.style.opacity = '1';
+    innerBar.style.pointerEvents = 'auto';
+    innerBar.style.visibility = 'visible';
+    innerBar.style.transform = 'scale(1)';
+  }
+
+  async function openPanel() {
+    container.classList.add('glov-voice-chat-panel-open');
+    if (!isMobile()) container.classList.add('glov-voice-chat-expanded');
+    hideInnerBar();
+
+    if (isMobile()) {
+      panel.classList.add('glov-voice-chat-fullscreen');
+      document.body.appendChild(panel);
+      document.documentElement.classList.add('glov-voice-fullscreen-open');
+    }
+
+    panel.style.display = 'block';
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        panel.classList.add('active');
+        resolve();
+      });
+    });
+  }
+
+  function closePanel() {
+    container.classList.remove('glov-voice-chat-panel-open', 'glov-voice-chat-expanded');
+    showInnerBar();
+
+    if (panel.classList.contains('glov-voice-chat-fullscreen')) {
+      panel.classList.remove('glov-voice-chat-fullscreen');
+      container.appendChild(panel);
+      document.documentElement.classList.remove('glov-voice-fullscreen-open');
+    }
+
+    panel.classList.remove('active');
+    panel.style.display = 'none';
+    setPanelState('idle');
+  }
+
+  // ── Waveform ────────────────────────────────────────────────────────────
+  function stopWaveform() {
+    if (waveFrameId !== null) {
+      cancelAnimationFrame(waveFrameId);
+      waveFrameId = null;
+    }
+    if (analyserNode) {
+      analyserNode.disconnect();
+      analyserNode = null;
+    }
+    if (audioCtx) {
+      audioCtx.close().catch(() => {});
+      audioCtx = null;
+    }
+  }
+
+  async function startMicWaveform() {
+    if (audioCtx) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      audioCtx = new AudioContext();
+      analyserNode = audioCtx.createAnalyser();
+      analyserNode.fftSize = 256;
+      audioCtx.createMediaStreamSource(stream).connect(analyserNode);
+
+      const canvas = container.querySelector('#glov-audio-waveform') as HTMLCanvasElement | null;
+      if (!canvas) return;
+      const ctx2d = canvas.getContext('2d');
+      if (!ctx2d) return;
+
+      const buf = new Uint8Array(analyserNode.frequencyBinCount);
+      const draw = () => {
+        waveFrameId = requestAnimationFrame(draw);
+        analyserNode!.getByteTimeDomainData(buf);
+        ctx2d.clearRect(0, 0, canvas.width, canvas.height);
+        ctx2d.beginPath();
+        ctx2d.strokeStyle = 'rgba(255,255,255,0.7)';
+        ctx2d.lineWidth = 2;
+        const step = canvas.width / buf.length;
+        let x = 0;
+        for (let i = 0; i < buf.length; i++) {
+          const y = (buf[i]! / 128) * (canvas.height / 2);
+          i === 0 ? ctx2d.moveTo(x, y) : ctx2d.lineTo(x, y);
+          x += step;
+        }
+        ctx2d.stroke();
+      };
+      draw();
+    } catch {
+      // Microphone already acquired or permission denied — ignore
+    }
+  }
+
+  // ── Backend helpers ─────────────────────────────────────────────────────
+  async function getSignedUrl(): Promise<string> {
+    if (!cachedAgentId) {
+      const r = await fetch(`${middlewareUrl}/agents/id`);
+      if (!r.ok) throw new Error(`Agent ID fetch failed: ${r.status}`);
+      const data = (await r.json()) as { agent_id: string };
+      cachedAgentId = data.agent_id;
+    }
+
+    const r = await fetch(
+      `${middlewareUrl}/agents/conversations/token?agent_id=${encodeURIComponent(cachedAgentId)}`
+    );
+    if (!r.ok) throw new Error(`Token fetch failed: ${r.status}`);
+    const data = (await r.json()) as { token: string };
+    return data.token;
+  }
+
+  // ── Session ─────────────────────────────────────────────────────────────
+  async function startSession() {
+    const attemptId = ++sessionAttemptId;
+    setPanelState('connecting');
+    await openPanel();
+    if (attemptId !== sessionAttemptId) return;
+
+    try {
+      const signedUrl = await getSignedUrl();
+      if (attemptId !== sessionAttemptId) return;
+
+      const next = await Conversation.startSession({
+        signedUrl,
+        onConnect: () => {
+          if (attemptId !== sessionAttemptId) return;
+          setPanelState('connecting');
+        },
+        onDisconnect: () => {
+          if (attemptId !== sessionAttemptId) return;
+          stopWaveform();
+          closePanel();
+          conversation = null;
+        },
+        onError: (err: unknown) => {
+          if (attemptId !== sessionAttemptId) return;
+          console.error('[voice]', err);
+          setPanelState('error');
+        },
+        onModeChange: (mode: { mode: 'speaking' | 'listening' }) => {
+          if (attemptId !== sessionAttemptId) return;
+          if (mode.mode === 'listening') {
+            setPanelState('listening');
+            void startMicWaveform();
+          } else {
+            setPanelState('speaking');
+          }
+        },
+      } as Parameters<typeof Conversation.startSession>[0]);
+
+      if (attemptId !== sessionAttemptId) {
+        void next.endSession().catch(() => {});
+        return;
+      }
+      conversation = next;
+    } catch (err) {
+      if (attemptId !== sessionAttemptId) return;
+      console.error('[voice] session start failed:', err);
+      setPanelState('error');
+    }
+  }
+
+  async function endSession() {
+    const active = conversation;
+    sessionAttemptId++;
+    conversation = null;
+    stopWaveform();
+    closePanel();
+    if (active) {
+      await active.endSession().catch((err: unknown) => console.error('[voice] end error:', err));
+    }
+  }
+
+  // ── Layout sync ─────────────────────────────────────────────────────────
+  function syncLayout() {
+    const desktop = !isMobile();
+    container.classList.toggle('glov-voice-chat-desktop-launcher', desktop);
+    callLabel.textContent = desktop ? "Uzman'a Sor" : 'Uzmanla Görüş';
+  }
+
+  // ── Event bindings ──────────────────────────────────────────────────────
+  let lastPress = 0;
+  function bindPress(el: HTMLElement, handler: () => Promise<void> | void) {
+    const run = (e: Event) => {
+      const now = Date.now();
+      if (now - lastPress < 250) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      lastPress = now;
+      e.preventDefault();
+      e.stopPropagation();
+      void handler();
+    };
+    el.addEventListener('pointerup', run);
+    el.addEventListener('click', run);
+  }
+
+  bindPress(callButton, startSession);
+  bindPress(closeBtn, endSession);
+  bindPress(endBtn, endSession);
+
+  setPanelState('idle');
+  syncLayout();
+  window.addEventListener('resize', syncLayout);
+
+  return container;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "zod": "^4.3.6"
       },
       "devDependencies": {
+        "@elevenlabs/client": "^0.12.2",
         "@playwright/test": "^1.58.2",
         "@types/node": "^25.5.0",
         "eslint": "^10.1.0",
@@ -401,6 +402,13 @@
         "specificity": "bin/cli.js"
       }
     },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "dev": true,
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
@@ -591,6 +599,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@elevenlabs/client": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/client/-/client-0.12.2.tgz",
+      "integrity": "sha512-QWllhDndFfKmftlktNoa35+AF3gOCbSHowYhR42ZHb5u32lFbMPbh2BALCrpFa3edqCHSXtzG6zzLSAGjkhvHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@elevenlabs/types": "0.4.0",
+        "livekit-client": "^2.11.4"
+      }
+    },
+    "node_modules/@elevenlabs/types": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@elevenlabs/types/-/types-0.4.0.tgz",
+      "integrity": "sha512-6CQb4r9DjepILhLybDxW0h8rvbsR8jPAp74HvFGYuvYdXcQRTkYTD9BQ4PV6VcuC1iqx0UljzJj8js3ADQ8EXw==",
+      "dev": true
     },
     "node_modules/@emnapi/core": {
       "version": "1.9.2",
@@ -1279,6 +1304,23 @@
       },
       "peerDependencies": {
         "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.44.0.tgz",
+      "integrity": "sha512-/vfhDUGcUKO8Q43r6i+5FrDhl5oZjm/X3U4x2Iciqvgn5C8qbj+57YPcWSJ1kyIZm5Cm6AV2nAPjMm3ETD/iyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
       }
     },
     "node_modules/@microsoft/api-extractor": {
@@ -2428,6 +2470,14 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
@@ -3900,6 +3950,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4322,6 +4382,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/jsdom": {
       "version": "29.0.2",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
@@ -4701,6 +4771,27 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/livekit-client": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.1.tgz",
+      "integrity": "sha512-nGjuEEV1mVN01EcAMwGIwG3J1gpBMqwn2V4R6W/8zz9Rah1CaAohIm6AMLG7BdctQpyeh34dfAOLfDodIsWyYA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.44.0",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
     "node_modules/local-pkg": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
@@ -4741,6 +4832,20 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/lru-cache": {
       "version": "11.3.3",
@@ -5450,6 +5555,17 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -5461,6 +5577,23 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/search-insights": {
@@ -5806,8 +5939,7 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -5855,6 +5987,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
       }
     },
     "node_modules/typescript": {
@@ -6863,6 +7005,20 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.4.tgz",
+      "integrity": "sha512-5ZZY1+lGq8LEKuDlg9M2RPJHlH3R7OVwyHqMcUsLKCgd9Wvf+QrFTCItkXXYPmrJn8H6gRLXbSgxLLdexiqHxw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "prepublishOnly": "npm run typecheck && npm run test && npm run build"
   },
   "devDependencies": {
+    "@elevenlabs/client": "^0.12.2",
     "@playwright/test": "^1.58.2",
     "@types/node": "^25.5.0",
     "eslint": "^10.1.0",


### PR DESCRIPTION
## Summary

- Adds `demos/otokoccomtr/` — a complete Otokoç automotive dealer demo page
- Chat widget initialized via `initOverlayWidgets` with navy Otokoç theme (`#0f2b5b`)
- Floating ElevenLabs voice launcher (`voice-launcher.ts`) adapted from `robot-engine-lean`
- Backend URL is read from `?middlewareUrl=` query param (defaults to `http://localhost:5990/api`)

## What's included

| File | Purpose |
|---|---|
| `demos/otokoccomtr/index.html` | Otokoç-branded car catalog page: brand filters, vehicle grid, hero banner. Initializes chat widget + voice launcher. |
| `demos/otokoccomtr/voice-launcher.ts` | Standalone TS voice widget: fetches agent token from `/api/agents/conversations/token`, starts ElevenLabs `Conversation` session, renders floating orb panel with waveform. |
| `demos/otokoccomtr/glov-otokoccomtr-launcher.svg` | Navy circle launcher icon with car silhouette. |
| `package.json` | Adds `@elevenlabs/client ^0.12.2` as devDependency (demos only). |

## Voice launcher architecture

The voice launcher replicates the production pattern from `robot-engine-lean`:
1. `GET {middlewareUrl}/agents/id` → cached agent ID
2. `GET {middlewareUrl}/agents/conversations/token?agent_id=...` → signed WebSocket URL
3. `Conversation.startSession({ signedUrl })` via `@elevenlabs/client`
4. Orb state machine: `idle → connecting → listening / speaking → idle`

Note: OTP/SMS handoff flow is intentionally omitted from this demo (that stays in `robot-engine-lean`).

## How to run

```bash
cd gengage-assistant-fe
npm install
# In another terminal: start otokoc-assistants backend
npm run dev   # starts all demos at :5173
# Open: http://localhost:5173/otokoccomtr/?middlewareUrl=http://localhost:5990/api
```

## Test plan

- [ ] Demo page loads with Otokoç navy branding
- [ ] Chat launcher appears (navy circle with car icon)
- [ ] Opening chat shows "Otokoç AI Asistan" header, Turkish input placeholder
- [ ] `initOverlayWidgets` connects to `{middlewareUrl}/chat/process_action`
- [ ] Voice launcher floating bar appears (bottom-right, above chat launcher)
- [ ] Clicking "Uzmanla Görüş" fetches agent token from backend and starts ElevenLabs session
- [ ] Orb state transitions: connecting → listening → speaking
- [ ] "Görüşmeyi Bitir" closes session and restores launcher bar
- [ ] Brand filter pills correctly filter the vehicle grid
- [ ] Works on mobile (fullscreen voice panel)