### PR TITLE
Qna launcher updates

### DIFF
--- a/demos/arcelikcomtr/index.html
+++ b/demos/arcelikcomtr/index.html
@@ -481,7 +481,6 @@
     <script type="module">
       import { initOverlayWidgets } from '@gengage/assistant-fe';
 
-      const launcherUrl = new URL('./glov-arcelikcomtr-launcher.svg', import.meta.url).href;
       const headerLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-arcelikcomtr-logo.png';
 
       const params = new URLSearchParams(location.search);
@@ -522,8 +521,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Çelik'e Sor",
-          launcherImageUrl: launcherUrl,
           headerAvatarUrl: headerLogoUrl,
+          pillLauncher: {
+            label: "Çelik'e Sor",
+            avatarUrl: headerLogoUrl,
+            primaryColor: '#d93131',
+            secondaryColor: '#222222',
+            fontFamily: '"Graphik", "Roboto", "Helvetica Neue", Arial, sans-serif',
+          },
         },
         qna: {
           mountTarget: '#arcelik-qna-section',

--- a/demos/arcelikcomtr/index.html
+++ b/demos/arcelikcomtr/index.html
@@ -527,6 +527,7 @@
         },
         qna: {
           mountTarget: '#arcelik-qna-section',
+          headerTitle: "Çelik'e Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/avansascom/index.html
+++ b/demos/avansascom/index.html
@@ -521,6 +521,7 @@
         },
         qna: {
           mountTarget: '#avansas-qna-section',
+          headerTitle: "Avansas'a Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/avansascom/index.html
+++ b/demos/avansascom/index.html
@@ -482,6 +482,8 @@
       document.getElementById('breadcrumb-sku').textContent = skuDisplay;
       document.getElementById('summary-sku').textContent = skuDisplay;
 
+      const avansasAvatarUrl = new URL('./avansas-avatar.svg', import.meta.url).href;
+
       const controller = await initOverlayWidgets({
         accountId: 'avansascom',
         middlewareUrl,
@@ -512,8 +514,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Avansas Asistan',
-          launcherImageUrl: new URL('./avansas-avatar.svg', import.meta.url).href,
-          headerAvatarUrl: new URL('./avansas-avatar.svg', import.meta.url).href,
+          headerAvatarUrl: avansasAvatarUrl,
+          pillLauncher: {
+            label: "Avansas'a Sor",
+            avatarUrl: avansasAvatarUrl,
+            primaryColor: '#F07E01',
+            secondaryColor: '#333333',
+            fontFamily: '"Open Sans", sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ofis malzemesi ara veya soru sor',
             poweredBy: 'Avansas AI Asistan',

--- a/demos/aygazcomtr/index.html
+++ b/demos/aygazcomtr/index.html
@@ -475,6 +475,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-aygazcomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -511,6 +512,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Aygaz Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Aygaz ürünleri hakkında sorun',
             poweredBy: 'Aygaz AI Asistan',
@@ -518,6 +521,7 @@
         },
         qna: {
           mountTarget: '#aygaz-qna-section',
+          headerTitle: "Aygaz'a Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/aygazcomtr/index.html
+++ b/demos/aygazcomtr/index.html
@@ -512,8 +512,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Aygaz Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Aygaz'a Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#e30613',
+            secondaryColor: '#333333',
+            fontFamily: 'Arial, Helvetica, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Aygaz ürünleri hakkında sorun',
             poweredBy: 'Aygaz AI Asistan',

--- a/demos/boynercomtr/index.html
+++ b/demos/boynercomtr/index.html
@@ -522,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Boyner Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Boyner'e Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#EE403D',
+            secondaryColor: '#333333',
+            fontFamily: '"Montserrat", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Moda, kozmetik veya ev ürünleri arayın',
             poweredBy: 'Boyner AI Asistan',

--- a/demos/boynercomtr/index.html
+++ b/demos/boynercomtr/index.html
@@ -485,6 +485,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-boynercomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -521,6 +522,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Boyner Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Moda, kozmetik veya ev ürünleri arayın',
             poweredBy: 'Boyner AI Asistan',
@@ -528,6 +531,7 @@
         },
         qna: {
           mountTarget: '#boyner-qna-section',
+          headerTitle: "Boyner'e Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/defactocomtr/index.html
+++ b/demos/defactocomtr/index.html
@@ -484,6 +484,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-defactocomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -520,6 +521,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'DeFacto Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ürün ara veya soru sor',
             poweredBy: 'DeFacto AI Asistan',
@@ -527,6 +530,7 @@
         },
         qna: {
           mountTarget: '#defacto-qna-section',
+          headerTitle: "DeFacto'ya Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/defactocomtr/index.html
+++ b/demos/defactocomtr/index.html
@@ -521,8 +521,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'DeFacto Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "DeFacto'ya Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#f28100',
+            secondaryColor: '#22242a',
+            fontFamily: 'system-ui, -apple-system, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ürün ara veya soru sor',
             poweredBy: 'DeFacto AI Asistan',

--- a/demos/divanpastanelericomtr/index.html
+++ b/demos/divanpastanelericomtr/index.html
@@ -513,8 +513,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Divan Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Divan'a Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#8b1a2d',
+            secondaryColor: '#3d2c2e',
+            fontFamily: '"Georgia", serif',
+          },
           i18n: {
             inputPlaceholder: 'Ürün veya mağaza arayın',
             poweredBy: 'Divan AI Asistan',

--- a/demos/divanpastanelericomtr/index.html
+++ b/demos/divanpastanelericomtr/index.html
@@ -476,6 +476,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-divanpastanelericomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -512,6 +513,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Divan Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ürün veya mağaza arayın',
             poweredBy: 'Divan AI Asistan',
@@ -519,6 +522,7 @@
         },
         qna: {
           mountTarget: '#divan-qna-section',
+          headerTitle: "Divan'a Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/evideacom/index.html
+++ b/demos/evideacom/index.html
@@ -513,8 +513,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Evidea Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Evidea'ya Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#ff6a00',
+            secondaryColor: '#2d3436',
+            fontFamily: '"Poppins", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ev dekorasyon ürünleri arayın',
             poweredBy: 'Evidea AI Asistan',

--- a/demos/evideacom/index.html
+++ b/demos/evideacom/index.html
@@ -476,6 +476,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-evideacom-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -512,6 +513,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Evidea Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ev dekorasyon ürünleri arayın',
             poweredBy: 'Evidea AI Asistan',
@@ -519,6 +522,7 @@
         },
         qna: {
           mountTarget: '#evidea-qna-section',
+          headerTitle: "Evidea'ya Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/flocomtr/index.html
+++ b/demos/flocomtr/index.html
@@ -485,6 +485,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-flocomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -521,6 +522,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'FLO Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ayakkabı veya aksesuar arayın',
             poweredBy: 'FLO AI Asistan',
@@ -528,6 +531,7 @@
         },
         qna: {
           mountTarget: '#flo-qna-section',
+          headerTitle: "FLO'ya Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/flocomtr/index.html
+++ b/demos/flocomtr/index.html
@@ -522,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'FLO Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "FLO'ya Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#FF6600',
+            secondaryColor: '#000000',
+            fontFamily: '"Roboto", sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ayakkabı veya aksesuar arayın',
             poweredBy: 'FLO AI Asistan',

--- a/demos/flormarcomtr/index.html
+++ b/demos/flormarcomtr/index.html
@@ -542,7 +542,6 @@
       document.getElementById('summary-sku').textContent = skuDisplay;
 
       const avatarUrl = new URL('./hande.jpg', import.meta.url).href;
-      const launcherBootstrapImage = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
       const controller = await initOverlayWidgets({
         accountId: 'flormarcomtr',
@@ -574,8 +573,16 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Hande'ye Sor",
-          launcherImageUrl: launcherBootstrapImage,
           headerAvatarUrl: avatarUrl,
+          pillLauncher: {
+            label: "Floarmar'a Sor",
+            avatarUrl,
+            primaryColor: '#E45A80',
+            secondaryColor: '#0f0f0f',
+            fontFamily: '"Montserrat", "Helvetica Neue", Arial, sans-serif',
+            labelClassName: 'flormar-launcher-label',
+            styleId: 'flormar-pill-launcher-style',
+          },
           i18n: {
             inputPlaceholder: 'Bu ürünle ilgili soru sor',
             poweredBy: 'Flormar AI Asistan',
@@ -610,122 +617,6 @@
       });
 
       document.getElementById('dev-session').textContent = controller.session.sessionId;
-
-      const flormarLauncherCss = `
-        .gengage-chat-launcher-container {
-          right: 22px;
-          bottom: 22px;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-          width: 188px;
-          min-width: 188px;
-          max-width: 188px;
-          height: 58px;
-          padding: 6px 8px 6px 18px;
-          display: inline-flex;
-          flex-direction: row-reverse;
-          align-items: center;
-          justify-content: space-between;
-          gap: 10px;
-          border-radius: 999px;
-          border: 1px solid color-mix(in srgb, var(--client-primary) 18%, #ffffff);
-          background: #ffffff;
-          box-shadow:
-            0 16px 36px color-mix(in srgb, var(--client-primary) 18%, transparent),
-            0 4px 12px color-mix(in srgb, #1f2937 8%, transparent);
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode:hover {
-          transform: translateY(-1px);
-          box-shadow:
-            0 20px 42px color-mix(in srgb, var(--client-primary) 24%, transparent),
-            0 6px 16px color-mix(in srgb, #1f2937 12%, transparent);
-        }
-
-        .flormar-launcher-label {
-          color: #1f2937;
-          font: 500 14px/1.1 var(--brand-font);
-          letter-spacing: -0.01em;
-          white-space: nowrap;
-          flex: 0 0 auto;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-          width: 44px;
-          height: 44px;
-          flex: 0 0 44px;
-          border-radius: 999px;
-          object-fit: cover;
-          object-position: center 38%;
-          background: transparent;
-          border: 0;
-          box-shadow: none;
-        }
-
-        @media (max-width: 768px) {
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-            width: 172px;
-            min-width: 172px;
-            max-width: 172px;
-            height: 54px;
-            padding-left: 18px;
-            padding-right: 8px;
-          }
-
-          .flormar-launcher-label {
-            font-size: 13px;
-          }
-
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-            width: 38px;
-            height: 38px;
-            flex-basis: 38px;
-          }
-        }
-      `;
-
-      const enhanceFlormarLauncher = () => {
-        const host = document.querySelector('[data-gengage-widget="gengagechat"]');
-        const root = host instanceof HTMLElement ? host.shadowRoot : null;
-        if (!root) return false;
-
-        if (!root.getElementById('flormar-launcher-style')) {
-          const style = document.createElement('style');
-          style.id = 'flormar-launcher-style';
-          style.textContent = flormarLauncherCss;
-          root.appendChild(style);
-        }
-
-        const launcher = root.querySelector('[data-gengage-part="chat-launcher-button"]');
-        if (!(launcher instanceof HTMLButtonElement)) return false;
-        const launcherImg = launcher.querySelector('img');
-        if (launcherImg instanceof HTMLImageElement && launcherImg.getAttribute('src') !== avatarUrl) {
-          launcherImg.src = avatarUrl;
-        }
-        // The bootstrap placeholder launcher makes launcherImageUrl !== headerAvatarUrl, which
-        // causes ChatDrawer to apply logo styling to the header avatar. Restore circular treatment.
-        const headerAvatar = root.querySelector('[data-gengage-part="chat-header-avatar"]');
-        if (headerAvatar instanceof HTMLImageElement) {
-          headerAvatar.classList.remove('gengage-chat-header-avatar--logo');
-        }
-        if (launcher.querySelector('.flormar-launcher-label')) return true;
-
-        launcher.setAttribute('aria-label', "Hande'ye Sor");
-        const label = document.createElement('span');
-        label.className = 'flormar-launcher-label';
-        label.textContent = "Hande'ye Sor";
-        launcher.appendChild(label);
-        return true;
-      };
-
-      if (!enhanceFlormarLauncher()) {
-        const launcherObserver = new MutationObserver(() => {
-          if (enhanceFlormarLauncher()) launcherObserver.disconnect();
-        });
-        launcherObserver.observe(document.body, { childList: true, subtree: true });
-        window.setTimeout(() => launcherObserver.disconnect(), 5000);
-      }
     </script>
   </body>
 </html>

--- a/demos/flormarcomtr/index.html
+++ b/demos/flormarcomtr/index.html
@@ -575,7 +575,7 @@
           headerTitle: "Hande'ye Sor",
           headerAvatarUrl: avatarUrl,
           pillLauncher: {
-            label: "Floarmar'a Sor",
+            label: "Flormar'a Sor",
             avatarUrl,
             primaryColor: '#E45A80',
             secondaryColor: '#0f0f0f',

--- a/demos/flormarcomtr/index.html
+++ b/demos/flormarcomtr/index.html
@@ -583,6 +583,7 @@
         },
         qna: {
           mountTarget: '#flormar-qna-section',
+          headerTitle: "Hande'ye Sor",
           hideButtonRowCta: true,
           inputPlaceholder: true,
           i18n: {

--- a/demos/hepsiburadacom/index.html
+++ b/demos/hepsiburadacom/index.html
@@ -520,8 +520,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Hepsiburada Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Hepsiburada'ya Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#ff6000',
+            secondaryColor: '#212529',
+            fontFamily: '"Nunito Sans", "Arial", sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Hepsiburada asistanına sorun...',
             poweredBy: 'Hepsiburada AI Asistan',

--- a/demos/hepsiburadacom/index.html
+++ b/demos/hepsiburadacom/index.html
@@ -484,6 +484,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-hepsiburadacom-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -518,6 +519,9 @@
         chat: {
           variant: 'floating',
           mobileBreakpoint: 768,
+          headerTitle: 'Hepsiburada Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Hepsiburada asistanına sorun...',
             poweredBy: 'Hepsiburada AI Asistan',
@@ -525,6 +529,8 @@
         },
         qna: {
           mountTarget: '#hb-qna-section',
+          headerTitle: "Hepsiburada'ya Sor",
+          ctaText: 'Başka bir şey sor',
         },
         simrel: {
           mountTarget: '#hb-similar-products',

--- a/demos/koctascomtr/index.html
+++ b/demos/koctascomtr/index.html
@@ -485,7 +485,7 @@
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
 
-      const launcherUrl = new URL('./glov-koctascomtr-launcher.svg', import.meta.url).href;
+      const koctasLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-koctascomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -522,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Koçtaş Robotu',
-          launcherImageUrl: launcherUrl,
-          headerAvatarUrl: 'https://configs.glov.ai/remoteConfig/glov-koctascomtr-logo.svg',
+          headerAvatarUrl: koctasLogoUrl,
+          pillLauncher: {
+            label: "Koçtaş'a Sor",
+            avatarUrl: koctasLogoUrl,
+            primaryColor: '#ec6e00',
+            secondaryColor: '#222222',
+            fontFamily: '"Source Sans Pro", "Helvetica Neue", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ürün ara, soru sor',
             poweredBy: 'Koçtaş AI Asistan',

--- a/demos/koctascomtr/index.html
+++ b/demos/koctascomtr/index.html
@@ -531,6 +531,7 @@
         },
         qna: {
           mountTarget: '#koctas-qna-section',
+          headerTitle: "Koçtaş'a Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/lcwcom/index.html
+++ b/demos/lcwcom/index.html
@@ -485,6 +485,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-lcwcom-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -521,6 +522,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'LC Waikiki Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ürün ara veya soru sor',
             poweredBy: 'LC Waikiki AI Asistan',
@@ -528,6 +531,7 @@
         },
         qna: {
           mountTarget: '#lcw-qna-section',
+          headerTitle: "LC Waikiki'ye Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/lcwcom/index.html
+++ b/demos/lcwcom/index.html
@@ -522,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'LC Waikiki Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "LC Waikiki'ye Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#B82020',
+            secondaryColor: '#0C0B37',
+            fontFamily: '"Metropolis", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ürün ara veya soru sor',
             poweredBy: 'LC Waikiki AI Asistan',

--- a/demos/n11com/index.html
+++ b/demos/n11com/index.html
@@ -541,6 +541,8 @@
         },
         qna: {
           mountTarget: '#n11-qna-section',
+          headerTitle: "n11'e Sor",
+          ctaText: 'Başka bir şey sor',
         },
         simrel: {
           mountTarget: '#n11-similar-products',

--- a/demos/n11com/index.html
+++ b/demos/n11com/index.html
@@ -500,7 +500,6 @@
       document.getElementById('summary-sku').textContent = skuDisplay;
       const n11LauncherIconUrl = new URL('./n11-launcher-icon.svg', import.meta.url).href;
       const n11HeaderLogoUrl = new URL('./n11-header-logo.png', import.meta.url).href;
-      const launcherBootstrapImage = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
       const controller = await initOverlayWidgets({
         accountId: 'n11com',
@@ -532,8 +531,16 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "n11'e Sor",
-          launcherImageUrl: launcherBootstrapImage,
           headerAvatarUrl: n11HeaderLogoUrl,
+          pillLauncher: {
+            label: "n11'e Sor",
+            avatarUrl: n11LauncherIconUrl,
+            primaryColor: '#ff44ef',
+            secondaryColor: '#1f2937',
+            fontFamily: '"Poppins", "Open Sans", Arial, sans-serif',
+            labelClassName: 'n11-launcher-label',
+            styleId: 'n11-pill-launcher-style',
+          },
           i18n: {
             inputPlaceholder: 'N11 asistanına sorun...',
             poweredBy: 'Gengage',
@@ -562,122 +569,6 @@
       });
 
       document.getElementById('dev-session').textContent = controller.session.sessionId;
-
-      const n11LauncherCss = `
-        .gengage-chat-launcher-container {
-          right: 22px;
-          bottom: 22px;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-          width: 184px;
-          min-width: 184px;
-          max-width: 184px;
-          height: 58px;
-          padding: 6px 9px 6px 20px;
-          display: inline-flex;
-          flex-direction: row-reverse;
-          align-items: center;
-          justify-content: center;
-          gap: 8px;
-          border-radius: 999px;
-          border: 1px solid color-mix(in srgb, var(--client-primary) 18%, #ffffff);
-          background: #ffffff;
-          box-shadow:
-            0 8px 20px color-mix(in srgb, var(--client-primary) 12%, transparent),
-            0 2px 8px color-mix(in srgb, #1f2937 6%, transparent);
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode:hover {
-          transform: translateY(-1px);
-          box-shadow:
-            0 10px 24px color-mix(in srgb, var(--client-primary) 16%, transparent),
-            0 3px 10px color-mix(in srgb, #1f2937 8%, transparent);
-        }
-
-        .n11-launcher-label {
-          color: #1f2937;
-          font: 500 14px/1.1 var(--brand-font);
-          letter-spacing: -0.01em;
-          white-space: nowrap;
-          flex: 0 0 auto;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-          width: 36px;
-          height: 36px;
-          flex: 0 0 36px;
-          border-radius: 999px;
-          object-fit: cover;
-          object-position: center;
-          background: transparent;
-          border: 0;
-          box-shadow: none;
-        }
-
-        .gengage-chat-header-avatar--logo {
-          max-width: 94px;
-          height: 36px;
-        }
-
-        @media (max-width: 768px) {
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-            width: 172px;
-            min-width: 172px;
-            max-width: 172px;
-            height: 54px;
-            padding-left: 18px;
-            padding-right: 8px;
-          }
-
-          .n11-launcher-label {
-            font-size: 13px;
-          }
-
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-            width: 34px;
-            height: 34px;
-            flex-basis: 34px;
-          }
-        }
-      `;
-
-      const enhanceN11Launcher = () => {
-        const host = document.querySelector('[data-gengage-widget="gengagechat"]');
-        const root = host instanceof HTMLElement ? host.shadowRoot : null;
-        if (!root) return false;
-
-        if (!root.getElementById('n11-launcher-style')) {
-          const style = document.createElement('style');
-          style.id = 'n11-launcher-style';
-          style.textContent = n11LauncherCss;
-          root.appendChild(style);
-        }
-
-        const launcher = root.querySelector('[data-gengage-part="chat-launcher-button"]');
-        if (!(launcher instanceof HTMLButtonElement)) return false;
-        const launcherImg = launcher.querySelector('img');
-        if (launcherImg instanceof HTMLImageElement && launcherImg.getAttribute('src') !== n11LauncherIconUrl) {
-          launcherImg.src = n11LauncherIconUrl;
-        }
-        if (launcher.querySelector('.n11-launcher-label')) return true;
-        launcher.setAttribute('aria-label', "n11'e Sor");
-        const label = document.createElement('span');
-        label.className = 'n11-launcher-label';
-        label.textContent = "n11'e Sor";
-        launcher.appendChild(label);
-        return true;
-      };
-
-      if (!enhanceN11Launcher()) {
-        const launcherObserver = new MutationObserver(() => {
-          if (enhanceN11Launcher()) {
-            launcherObserver.disconnect();
-          }
-        });
-        launcherObserver.observe(document.body, { childList: true, subtree: true });
-        window.setTimeout(() => launcherObserver.disconnect(), 5000);
-      }
 
       // Demo host-page "Sepete Ekle" button — brief success feedback so the page
       // feels realistic on mobile (this would be the merchant's own cart logic).

--- a/demos/ozdilekteyimcom-magaza/index.html
+++ b/demos/ozdilekteyimcom-magaza/index.html
@@ -616,6 +616,7 @@
         },
         qna: {
           mountTarget: '#ozdilekteyimcom-magaza-qna-section',
+          headerTitle: "Özdilek'e Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/ozdilekteyimcom-magaza/index.html
+++ b/demos/ozdilekteyimcom-magaza/index.html
@@ -607,8 +607,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Alışveriş Asistanı',
-          launcherImageUrl: chatIconUrl,
           headerAvatarUrl: chatIconUrl,
+          pillLauncher: {
+            label: "Özdilek'e Sor",
+            avatarUrl: chatIconUrl,
+            primaryColor: '#F08A2B',
+            secondaryColor: '#2c2528',
+            fontFamily: "'Montserrat', sans-serif",
+          },
           i18n: {
             inputPlaceholder: 'Mağazada ne aramıştınız? (Örn: Sabahlık, Parfüm...)',
             poweredBy: 'Özdilekteyim AI Asistan',

--- a/demos/ozdilekteyimcom-market/index.html
+++ b/demos/ozdilekteyimcom-market/index.html
@@ -612,8 +612,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Market Asistanı',
-          launcherImageUrl: chatIconUrl,
           headerAvatarUrl: chatIconUrl,
+          pillLauncher: {
+            label: 'Market Asistanı',
+            avatarUrl: chatIconUrl,
+            primaryColor: '#1BB407',
+            secondaryColor: '#212529',
+            fontFamily: "'Montserrat', sans-serif",
+          },
           i18n: {
             inputPlaceholder: "Market'te ne aramıştınız? (Örn: Domates, süt...)",
             poweredBy: 'Özdilekteyim Market AI Asistanı',

--- a/demos/ozdilekteyimcom-market/index.html
+++ b/demos/ozdilekteyimcom-market/index.html
@@ -621,6 +621,7 @@
         },
         qna: {
           mountTarget: '#ozdilekteyimcom-market-qna-section',
+          headerTitle: 'Market Asistanı',
           ctaText: 'Markette başka bir şey sor',
         },
         simrel: {

--- a/demos/pazaramacom/index.html
+++ b/demos/pazaramacom/index.html
@@ -485,6 +485,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-pazaramacom-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -521,6 +522,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Pazarama Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ürün ara veya soru sor',
             poweredBy: 'Pazarama AI Asistan',
@@ -528,6 +531,7 @@
         },
         qna: {
           mountTarget: '#pazarama-qna-section',
+          headerTitle: "Pazarama'ya Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/pazaramacom/index.html
+++ b/demos/pazaramacom/index.html
@@ -522,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Pazarama Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Pazarama'ya Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#0039A6',
+            secondaryColor: '#2B2422',
+            fontFamily: 'system-ui, -apple-system, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ürün ara veya soru sor',
             poweredBy: 'Pazarama AI Asistan',

--- a/demos/penticom/index.html
+++ b/demos/penticom/index.html
@@ -562,6 +562,7 @@
         },
         qna: {
           mountTarget: '#penti-qna-section',
+          headerTitle: "Penti'ye Sor",
           hideButtonRowCta: true,
           inputPlaceholder: true,
           i18n: {

--- a/demos/penticom/index.html
+++ b/demos/penticom/index.html
@@ -553,8 +553,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Penti'ye Sor",
-          launcherImageUrl: sockAvatarUrl,
           headerAvatarUrl: sockAvatarUrl,
+          pillLauncher: {
+            label: "Penti'ye Sor",
+            avatarUrl: sockAvatarUrl,
+            primaryColor: '#E91E63',
+            secondaryColor: '#1a1a2e',
+            fontFamily: '"Inter", "Helvetica Neue", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Bu ürünle ilgili soru sor',
             poweredBy: 'Penti AI Asistan',

--- a/demos/saatvesaatcomtr/index.html
+++ b/demos/saatvesaatcomtr/index.html
@@ -571,6 +571,7 @@
         },
         qna: {
           mountTarget: '#saatvesaat-qna-section',
+          headerTitle: "Saat & Saat'e Sor",
           hideButtonRowCta: true,
           inputPlaceholder: true,
           i18n: {

--- a/demos/saatvesaatcomtr/index.html
+++ b/demos/saatvesaatcomtr/index.html
@@ -530,7 +530,6 @@
       document.getElementById('summary-sku').textContent = skuDisplay;
 
       const avatarUrl = new URL('./saatendlogo.jpg', import.meta.url).href;
-      const launcherBootstrapImage = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
 
       const controller = await initOverlayWidgets({
         accountId: 'saatvesaatcomtr',
@@ -562,8 +561,16 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Saat & Saat'e Sor",
-          launcherImageUrl: launcherBootstrapImage,
           headerAvatarUrl: avatarUrl,
+          pillLauncher: {
+            label: "Saat & Saat'e Sor",
+            avatarUrl,
+            primaryColor: '#590e2b',
+            secondaryColor: '#1a1a1a',
+            fontFamily: '"Roboto", "Helvetica Neue", Arial, sans-serif',
+            labelClassName: 'saat-launcher-label',
+            styleId: 'saat-pill-launcher-style',
+          },
           i18n: {
             inputPlaceholder: 'Bu ürünle ilgili soru sor',
             poweredBy: 'Saat & Saat AI Asistan',
@@ -598,122 +605,6 @@
       });
 
       document.getElementById('dev-session').textContent = controller.session.sessionId;
-
-      const saatLauncherCss = `
-        .gengage-chat-launcher-container {
-          right: 22px;
-          bottom: 22px;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-          width: 216px;
-          min-width: 216px;
-          max-width: 216px;
-          height: 58px;
-          padding: 6px 10px 6px 20px;
-          display: inline-flex;
-          flex-direction: row-reverse;
-          align-items: center;
-          justify-content: space-between;
-          gap: 12px;
-          border-radius: 999px;
-          border: 1px solid color-mix(in srgb, var(--client-primary) 18%, #ffffff);
-          background: #ffffff;
-          box-shadow:
-            0 16px 36px color-mix(in srgb, var(--client-primary) 18%, transparent),
-            0 4px 12px color-mix(in srgb, #1f2937 8%, transparent);
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode:hover {
-          transform: translateY(-1px);
-          box-shadow:
-            0 20px 42px color-mix(in srgb, var(--client-primary) 24%, transparent),
-            0 6px 16px color-mix(in srgb, #1f2937 12%, transparent);
-        }
-
-        .saat-launcher-label {
-          color: #1f2937;
-          font: 500 14px/1.1 var(--brand-font);
-          letter-spacing: -0.01em;
-          white-space: nowrap;
-          flex: 0 0 auto;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-          width: 36px;
-          height: 36px;
-          flex: 0 0 36px;
-          border-radius: 999px;
-          object-fit: cover;
-          object-position: center;
-          background: transparent;
-          border: 0;
-          box-shadow: none;
-        }
-
-        @media (max-width: 768px) {
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-            width: 186px;
-            min-width: 186px;
-            max-width: 186px;
-            height: 54px;
-            padding-left: 18px;
-            padding-right: 8px;
-          }
-
-          .saat-launcher-label {
-            font-size: 13px;
-          }
-
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-            width: 34px;
-            height: 34px;
-            flex-basis: 34px;
-          }
-        }
-      `;
-
-      const enhanceSaatLauncher = () => {
-        const host = document.querySelector('[data-gengage-widget="gengagechat"]');
-        const root = host instanceof HTMLElement ? host.shadowRoot : null;
-        if (!root) return false;
-
-        if (!root.getElementById('saat-launcher-style')) {
-          const style = document.createElement('style');
-          style.id = 'saat-launcher-style';
-          style.textContent = saatLauncherCss;
-          root.appendChild(style);
-        }
-
-        const launcher = root.querySelector('[data-gengage-part="chat-launcher-button"]');
-        if (!(launcher instanceof HTMLButtonElement)) return false;
-        const launcherImg = launcher.querySelector('img');
-        if (launcherImg instanceof HTMLImageElement && launcherImg.getAttribute('src') !== avatarUrl) {
-          launcherImg.src = avatarUrl;
-        }
-        // The bootstrap placeholder launcher makes launcherImageUrl !== headerAvatarUrl, which
-        // causes ChatDrawer to apply logo styling to the header avatar. Restore circular treatment.
-        const headerAvatar = root.querySelector('[data-gengage-part="chat-header-avatar"]');
-        if (headerAvatar instanceof HTMLImageElement) {
-          headerAvatar.classList.remove('gengage-chat-header-avatar--logo');
-        }
-        if (launcher.querySelector('.saat-launcher-label')) return true;
-
-        launcher.setAttribute('aria-label', "Saat & Saat'e Sor");
-        const label = document.createElement('span');
-        label.className = 'saat-launcher-label';
-        label.textContent = "Saat & Saat'e Sor";
-        launcher.appendChild(label);
-        return true;
-      };
-
-      if (!enhanceSaatLauncher()) {
-        const launcherObserver = new MutationObserver(() => {
-          if (enhanceSaatLauncher()) launcherObserver.disconnect();
-        });
-        launcherObserver.observe(document.body, { childList: true, subtree: true });
-        window.setTimeout(() => launcherObserver.disconnect(), 5000);
-      }
     </script>
   </body>
 </html>

--- a/demos/screwfixcom/index.html
+++ b/demos/screwfixcom/index.html
@@ -513,8 +513,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Screwfix Assistant',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: 'Screwfix Assistant',
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#00539f',
+            secondaryColor: '#333333',
+            fontFamily: '"Arial", sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Search products or ask a question',
             poweredBy: 'Screwfix AI Assistant',

--- a/demos/screwfixcom/index.html
+++ b/demos/screwfixcom/index.html
@@ -476,6 +476,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-screwfixcom-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -512,6 +513,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Screwfix Assistant',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Search products or ask a question',
             poweredBy: 'Screwfix AI Assistant',
@@ -519,6 +522,7 @@
         },
         qna: {
           mountTarget: '#screwfix-qna-section',
+          headerTitle: 'Screwfix Assistant',
           ctaText: 'Ask another question',
         },
         simrel: {

--- a/demos/skecherscomtr/index.html
+++ b/demos/skecherscomtr/index.html
@@ -490,6 +490,8 @@
       document.getElementById('breadcrumb-sku').textContent = skuDisplay;
       document.getElementById('summary-sku').textContent = skuDisplay;
 
+      const skechersAvatarUrl = new URL('./skechers-avatar.svg', import.meta.url).href;
+
       const controller = await initOverlayWidgets({
         accountId: 'skecherscomtr',
         middlewareUrl,
@@ -520,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Skechers Asistan',
-          launcherImageUrl: new URL('./skechers-avatar.svg', import.meta.url).href,
-          headerAvatarUrl: new URL('./skechers-avatar.svg', import.meta.url).href,
+          headerAvatarUrl: skechersAvatarUrl,
+          pillLauncher: {
+            label: "Skechers'a Sor",
+            avatarUrl: skechersAvatarUrl,
+            primaryColor: '#003478',
+            secondaryColor: '#333333',
+            fontFamily: '"Helvetica Neue", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ayakkabı ara veya soru sor',
             poweredBy: 'Skechers AI Asistan',

--- a/demos/skecherscomtr/index.html
+++ b/demos/skecherscomtr/index.html
@@ -529,6 +529,7 @@
         },
         qna: {
           mountTarget: '#skechers-qna-section',
+          headerTitle: "Skechers'a Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/teknosacom/index.html
+++ b/demos/teknosacom/index.html
@@ -345,120 +345,10 @@
         min-height: 180px;
       }
 
-      /* ── QNA section ── */
+      /* ── QNA section (widget styles: src/qna/components/qna.css + initOverlayWidgets theme) ── */
       .qna-section {
         margin-top: 14px;
         min-height: 72px;
-      }
-
-      #teknosa-qna-section .gengage-qna-container {
-        --gengage-font-family: var(--brand-font);
-        --gengage-font-size: 14px;
-        --gengage-qna-panel-bg: #f7f7f9;
-        --gengage-qna-panel-radius: 14px;
-        --gengage-qna-panel-margin-top: 4px;
-        --gengage-qna-panel-margin-bottom: 0;
-        --gengage-qna-pill-radius: 999px;
-        --gengage-qna-input-radius: 14px;
-        --gengage-qna-pill-bg: #fff;
-        --gengage-qna-pill-bg-hover: color-mix(in srgb, var(--brand-primary) 10%, white);
-        --gengage-qna-pill-fg: var(--brand-primary);
-        --gengage-qna-pill-border: color-mix(in srgb, var(--brand-primary) 64%, white);
-        --gengage-qna-pill-border-hover: color-mix(in srgb, var(--brand-primary) 78%, white);
-        --gengage-qna-input-bg: #fff;
-        --gengage-qna-input-border: color-mix(in srgb, var(--brand-primary) 58%, white);
-        --gengage-qna-icon-color: var(--brand-primary);
-        --gengage-qna-clear-color: var(--brand-primary);
-        --gengage-qna-send-color: var(--brand-primary);
-        --gengage-qna-send-color-disabled: color-mix(in srgb, var(--brand-primary) 36%, #b3b8c8);
-        --gengage-qna-action-icon-bg-hover: color-mix(in srgb, var(--brand-primary) 12%, white);
-      }
-
-      #teknosa-qna-section .gengage-qna-panel {
-        padding: 20px 22px 20px;
-        display: flex;
-        flex-direction: column;
-      }
-
-      #teknosa-qna-section .gengage-qna-heading {
-        font-size: clamp(24px, 2.3vw, 38px);
-        line-height: 1.1;
-        letter-spacing: -0.01em;
-        margin-bottom: 6px;
-      }
-
-      #teknosa-qna-section .gengage-qna-uispec {
-        display: flex;
-        flex-direction: column;
-        gap: 14px;
-      }
-
-      #teknosa-qna-section .gengage-qna-panel > .gengage-qna-uispec:has(.gengage-qna-heading) {
-        order: 0;
-      }
-
-      #teknosa-qna-section .gengage-qna-panel > .gengage-qna-uispec:has(.gengage-qna-input-wrapper) {
-        order: 1;
-      }
-
-      #teknosa-qna-section .gengage-qna-panel > .gengage-qna-uispec:has(.gengage-qna-buttons) {
-        order: 2;
-      }
-
-      #teknosa-qna-section .gengage-qna-panel > .gengage-qna-input-wrapper {
-        order: 1;
-      }
-
-      #teknosa-qna-section .gengage-qna-panel > .gengage-qna-buttons {
-        order: 2;
-      }
-
-      #teknosa-qna-section .gengage-qna-uispec > .gengage-qna-heading {
-        order: 0;
-      }
-
-      #teknosa-qna-section .gengage-qna-uispec > .gengage-qna-input-wrapper {
-        order: 1;
-        padding-top: 2px;
-        margin-bottom: 4px;
-      }
-
-      #teknosa-qna-section .gengage-qna-uispec > .gengage-qna-buttons {
-        order: 2;
-        padding-top: 10px;
-        gap: 14px 12px;
-      }
-
-      #teknosa-qna-section .gengage-qna-button,
-      #teknosa-qna-section .gengage-qna-cta {
-        min-height: 42px;
-        font-size: 15px;
-        padding: 9px 16px;
-        line-height: 1.2;
-      }
-
-      #teknosa-qna-section .gengage-qna-input {
-        font-size: 18px;
-        font-weight: 500;
-      }
-
-      #teknosa-qna-section .gengage-qna-input::placeholder {
-        color: #6b7280;
-      }
-
-      @media (max-width: 900px) {
-        #teknosa-qna-section .gengage-qna-panel {
-          padding: 16px 16px 16px;
-        }
-
-        #teknosa-qna-section .gengage-qna-uispec {
-          gap: 12px;
-        }
-
-        #teknosa-qna-section .gengage-qna-uispec > .gengage-qna-buttons {
-          padding-top: 8px;
-          gap: 10px;
-        }
       }
 
       /* ── Responsive ── */
@@ -589,7 +479,7 @@
     </main>
 
     <script type="module">
-      import { initOverlayWidgets } from '@gengage/assistant-fe';
+      import { initOverlayWidgets, makePillLauncher } from '@gengage/assistant-fe';
 
       const params = new URLSearchParams(location.search);
       const defaultSkus = ['125077817', '125077816', '125077820'];
@@ -626,7 +516,16 @@
       document.getElementById('gallery-main-title').textContent = productTitle;
       document.title = `Gengage Dev — teknosacom • ${skuDisplay}`;
       const avatarUrl = new URL('./teknosa-assistant-avatar.png', import.meta.url).href;
-      const launcherBootstrapImage = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
+
+      const pillLauncher = makePillLauncher({
+        label: "Teknosa'ya Sor",
+        avatarUrl,
+        primaryColor: '#F58220',
+        secondaryColor: '#0C0B37',
+        fontFamily: '"Metropolis", Arial, sans-serif',
+        labelClassName: 'teknosa-launcher-label',
+        styleId: 'teknosa-launcher-style',
+      });
 
       const controller = await initOverlayWidgets({
         accountId: 'teknosacom',
@@ -658,7 +557,7 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Teknosa'ya Sor",
-          launcherImageUrl: launcherBootstrapImage,
+          launcherImageUrl: pillLauncher.launcherImageUrl,
           headerAvatarUrl: avatarUrl,
           i18n: {
             inputPlaceholder: 'Ürün ara, soru sor',
@@ -667,6 +566,7 @@
         },
         qna: {
           mountTarget: '#teknosa-qna-section',
+          headerTitle: "Teknosa'ya Sor",
           ctaText: 'Başka bir şey sor',
           inputPlaceholder: true,
         },
@@ -685,165 +585,7 @@
 
       document.getElementById('dev-session').textContent = controller.session.sessionId;
 
-      const normalizeTeknosaQnaHeading = () => {
-        const qnaRoot = document.getElementById('teknosa-qna-section');
-        if (!qnaRoot) return;
-
-        qnaRoot.querySelectorAll('.gengage-qna-heading').forEach((heading) => {
-          if (!(heading instanceof HTMLElement)) return;
-          if (heading.textContent !== "Teknosa'ya Sor") {
-            heading.textContent = "Teknosa'ya Sor";
-          }
-        });
-      };
-
-      normalizeTeknosaQnaHeading();
-      const qnaRootEl = document.getElementById('teknosa-qna-section');
-      if (qnaRootEl) {
-        const prevObserver = window.__teknosaQnaObserver;
-        if (prevObserver instanceof MutationObserver) {
-          prevObserver.disconnect();
-        }
-        const qnaObserver = new MutationObserver(() => normalizeTeknosaQnaHeading());
-        qnaObserver.observe(qnaRootEl, { childList: true, subtree: false });
-        window.__teknosaQnaObserver = qnaObserver;
-      }
-
-      const teknosaLauncherCss = `
-        .gengage-chat-launcher-container {
-          right: 24px;
-          bottom: 24px;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-          width: 188px;
-          min-width: 188px;
-          max-width: 188px;
-          height: 60px;
-          padding: 6px 7px 6px 22px;
-          display: inline-flex;
-          flex-direction: row-reverse;
-          align-items: center;
-          justify-content: space-between;
-          gap: 12px;
-          border-radius: 999px;
-          border: 1px solid color-mix(in srgb, var(--brand-primary) 58%, white);
-          background: #ffffff;
-          box-shadow:
-            0 18px 46px color-mix(in srgb, var(--brand-secondary) 17%, transparent),
-            0 4px 14px color-mix(in srgb, var(--brand-secondary) 8%, transparent);
-          transition:
-            border-color 0.16s ease,
-            box-shadow 0.16s ease,
-            transform 0.16s ease;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode:hover {
-          border-color: color-mix(in srgb, var(--brand-primary) 78%, white);
-          transform: translateY(-1px);
-          box-shadow:
-            0 22px 52px color-mix(in srgb, var(--brand-secondary) 22%, transparent),
-            0 6px 18px color-mix(in srgb, var(--brand-secondary) 12%, transparent);
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode:focus-visible {
-          outline: 2px solid color-mix(in srgb, var(--brand-primary) 28%, transparent);
-          outline-offset: 2px;
-        }
-
-        .teknosa-launcher-label {
-          color: var(--brand-secondary);
-          font: 500 15px/1.05 var(--brand-font);
-          letter-spacing: -0.02em;
-          white-space: nowrap;
-          flex: 0 0 auto;
-        }
-
-        .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-          width: 46px;
-          height: 46px;
-          flex: 0 0 46px;
-          border-radius: 999px;
-          object-fit: cover;
-          object-position: center;
-          background: transparent;
-          border: 0;
-          box-shadow: none;
-        }
-
-        .gengage-chat-header-avatar {
-          width: 52px;
-          height: 52px;
-          border: 0;
-          box-shadow: none;
-          background: transparent;
-          object-fit: cover;
-          object-position: center;
-        }
-
-        @media (max-width: 768px) {
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode {
-            width: 174px;
-            min-width: 174px;
-            max-width: 174px;
-            height: 56px;
-            padding-left: 20px;
-            padding-right: 7px;
-          }
-
-          .teknosa-launcher-label {
-            font-size: 14px;
-          }
-
-          .gengage-chat-launcher.gengage-chat-launcher--image-mode img {
-            width: 42px;
-            height: 42px;
-            flex-basis: 42px;
-          }
-        }
-      `;
-
-      const enhanceTeknosaLauncher = () => {
-        const host = document.querySelector('[data-gengage-widget="gengagechat"]');
-        const root = host instanceof HTMLElement ? host.shadowRoot : null;
-        if (!root) return false;
-
-        if (!root.getElementById('teknosa-launcher-style')) {
-          const style = document.createElement('style');
-          style.id = 'teknosa-launcher-style';
-          style.textContent = teknosaLauncherCss;
-          root.appendChild(style);
-        }
-
-        const launcher = root.querySelector('[data-gengage-part="chat-launcher-button"]');
-        if (!(launcher instanceof HTMLButtonElement)) return false;
-        const launcherImg = launcher.querySelector('img');
-        if (launcherImg instanceof HTMLImageElement && launcherImg.getAttribute('src') !== avatarUrl) {
-          launcherImg.src = avatarUrl;
-        }
-        // The bootstrap placeholder launcher makes launcherImageUrl !== headerAvatarUrl, which
-        // causes ChatDrawer to apply logo styling to the header avatar. Restore circular treatment.
-        const headerAvatar = root.querySelector('[data-gengage-part="chat-header-avatar"]');
-        if (headerAvatar instanceof HTMLImageElement) {
-          headerAvatar.classList.remove('gengage-chat-header-avatar--logo');
-        }
-        if (launcher.querySelector('.teknosa-launcher-label')) return true;
-        launcher.setAttribute('aria-label', "Teknosa'ya Sor");
-        const label = document.createElement('span');
-        label.className = 'teknosa-launcher-label';
-        label.textContent = "Teknosa'ya Sor";
-        launcher.appendChild(label);
-        return true;
-      };
-      if (!enhanceTeknosaLauncher()) {
-        const launcherObserver = new MutationObserver(() => {
-          if (enhanceTeknosaLauncher()) {
-            launcherObserver.disconnect();
-          }
-        });
-        launcherObserver.observe(document.body, { childList: true, subtree: true });
-        window.setTimeout(() => launcherObserver.disconnect(), 5000);
-      }
+      await pillLauncher.apply();
 
       // Demo host-page "Sepete Ekle" button — brief success feedback so the page
       // feels realistic on mobile (this would be the merchant's own cart logic).

--- a/demos/teknosacom/index.html
+++ b/demos/teknosacom/index.html
@@ -479,7 +479,7 @@
     </main>
 
     <script type="module">
-      import { initOverlayWidgets, makePillLauncher } from '@gengage/assistant-fe';
+      import { initOverlayWidgets } from '@gengage/assistant-fe';
 
       const params = new URLSearchParams(location.search);
       const defaultSkus = ['125077817', '125077816', '125077820'];
@@ -517,16 +517,6 @@
       document.title = `Gengage Dev — teknosacom • ${skuDisplay}`;
       const avatarUrl = new URL('./teknosa-assistant-avatar.png', import.meta.url).href;
 
-      const pillLauncher = makePillLauncher({
-        label: "Teknosa'ya Sor",
-        avatarUrl,
-        primaryColor: '#F58220',
-        secondaryColor: '#0C0B37',
-        fontFamily: '"Metropolis", Arial, sans-serif',
-        labelClassName: 'teknosa-launcher-label',
-        styleId: 'teknosa-launcher-style',
-      });
-
       const controller = await initOverlayWidgets({
         accountId: 'teknosacom',
         middlewareUrl,
@@ -557,8 +547,16 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Teknosa'ya Sor",
-          launcherImageUrl: pillLauncher.launcherImageUrl,
           headerAvatarUrl: avatarUrl,
+          pillLauncher: {
+            label: "Teknosa'ya Sor",
+            avatarUrl,
+            primaryColor: '#F58220',
+            secondaryColor: '#0C0B37',
+            fontFamily: '"Metropolis", Arial, sans-serif',
+            labelClassName: 'teknosa-launcher-label',
+            styleId: 'teknosa-launcher-style',
+          },
           i18n: {
             inputPlaceholder: 'Ürün ara, soru sor',
             poweredBy: 'Gengage ile',
@@ -584,8 +582,6 @@
       });
 
       document.getElementById('dev-session').textContent = controller.session.sessionId;
-
-      await pillLauncher.apply();
 
       // Demo host-page "Sepete Ekle" button — brief success feedback so the page
       // feels realistic on mobile (this would be the merchant's own cart logic).

--- a/demos/trendyolcom/index.html
+++ b/demos/trendyolcom/index.html
@@ -485,6 +485,7 @@
       const params = new URLSearchParams(location.search);
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
+      const brandRemoteLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-trendyolcom-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -521,6 +522,8 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Trendyol Asistan',
+          launcherImageUrl: brandRemoteLogoUrl,
+          headerAvatarUrl: brandRemoteLogoUrl,
           i18n: {
             inputPlaceholder: 'Ne aramıştınız?',
             poweredBy: 'Trendyol AI Asistan',
@@ -528,6 +531,7 @@
         },
         qna: {
           mountTarget: '#trendyol-qna-section',
+          headerTitle: "Trendyol'a Sor",
           ctaText: 'Başka bir şey sor',
         },
         simrel: {

--- a/demos/trendyolcom/index.html
+++ b/demos/trendyolcom/index.html
@@ -522,8 +522,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: 'Trendyol Asistan',
-          launcherImageUrl: brandRemoteLogoUrl,
           headerAvatarUrl: brandRemoteLogoUrl,
+          pillLauncher: {
+            label: "Trendyol'a Sor",
+            avatarUrl: brandRemoteLogoUrl,
+            primaryColor: '#f27a1a',
+            secondaryColor: '#333333',
+            fontFamily: '"Source Sans Pro", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Ne aramıştınız?',
             poweredBy: 'Trendyol AI Asistan',

--- a/demos/yatasbeddingcomtr/index.html
+++ b/demos/yatasbeddingcomtr/index.html
@@ -529,6 +529,7 @@
         },
         qna: {
           mountTarget: '#yatas-qna-section',
+          headerTitle: "Yataş'a Sor",
           hideButtonRowCta: true,
           inputPlaceholder: true,
           i18n: {

--- a/demos/yatasbeddingcomtr/index.html
+++ b/demos/yatasbeddingcomtr/index.html
@@ -479,7 +479,7 @@
       const sku = params.get('sku') ?? undefined;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
 
-      const launcherUrl = new URL('./glov-yatasbeddingcomtr-launcher.svg', import.meta.url).href;
+      const yatasLogoUrl = 'https://configs.glov.ai/remoteConfig/glov-yatasbeddingcomtr-logo.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;
@@ -515,8 +515,14 @@
           variant: 'floating',
           mobileBreakpoint: 768,
           headerTitle: "Yataş'a Sor",
-          launcherImageUrl: launcherUrl,
-          headerAvatarUrl: 'https://configs.glov.ai/remoteConfig/glov-yatasbeddingcomtr-logo.svg',
+          headerAvatarUrl: yatasLogoUrl,
+          pillLauncher: {
+            label: "Yataş'a Sor",
+            avatarUrl: yatasLogoUrl,
+            primaryColor: '#4097ca',
+            secondaryColor: '#222222',
+            fontFamily: '"Inter", "Helvetica Neue", Arial, sans-serif',
+          },
           i18n: {
             inputPlaceholder: 'Bu ürünle ilgili soru sor',
             poweredBy: 'Yataş Bedding AI Asistan',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.15",
+      "version": "0.3.16",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -1414,6 +1414,11 @@ export class ChatDrawer {
     this._kvkkSlot.innerHTML = '';
   }
 
+  /** True when the KVKK banner is mounted (user has not dismissed it yet). */
+  isKvkkBannerVisible(): boolean {
+    return this._kvkkSlot.childNodes.length > 0;
+  }
+
   getElement(): HTMLElement {
     return this.root;
   }

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -71,6 +71,7 @@ import { SessionPersistence } from './session-persistence.js';
 import { ChatPresentationState, getLatestUnreadAssistantThreadId } from './chat-presentation-state.js';
 import { invalidateChatScrollCache } from './utils/get-chat-scroll-element.js';
 import { isLikelyConnectivityIssue } from '../common/global-error-toast.js';
+import { makePillLauncher } from '../common/pill-launcher.js';
 import { shouldShowStreamErrorAsRedStrip } from './stream-error-display.js';
 import {
   containsKvkk,
@@ -140,6 +141,8 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
   private _drawer: ChatDrawer | null = null;
   private _bridge: CommunicationBridge | null = null;
   private _drawerVisible = false;
+  /** Set when `config.pillLauncher` is used — `apply()` runs at end of `onInit`. */
+  private _pillLauncherApply: (() => Promise<void>) | null = null;
   /**
    * Host scroll blocked via capture-phase `touchmove`/`wheel` + preventDefault.
    * Does not set `overflow` on html/body (avoids breaking host layouts).
@@ -243,6 +246,15 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
   protected async onInit(config: ChatWidgetConfig): Promise<void> {
     this._i18n = this._resolveI18n(config);
     this._chatCreatedAt = new Date().toISOString();
+
+    if (config.pillLauncher) {
+      const kit = makePillLauncher(config.pillLauncher);
+      config.launcherImageUrl = kit.launcherImageUrl;
+      if (config.headerAvatarUrl === undefined) {
+        config.headerAvatarUrl = config.pillLauncher.avatarUrl;
+      }
+      this._pillLauncherApply = () => kit.apply();
+    }
 
     // Create Shadow DOM for CSS isolation
     this._shadow = this.root.attachShadow({ mode: 'open' });
@@ -513,6 +525,11 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       this._sendAction(pending.action, pending.options);
     }
     this._pendingActions = [];
+
+    if (this._pillLauncherApply && variant === 'floating') {
+      await this._pillLauncherApply();
+      this._pillLauncherApply = null;
+    }
 
     dispatch('gengage:chat:ready', {});
     ga.trackInit('chat');

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1372,6 +1372,14 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       return;
     }
 
+    // First outgoing user message: mark KVKK accepted so `kvkkApproved` is true on this request;
+    // if banner is still visible on a later send, dismiss it without requiring ×.
+    const isFirstUserMessage = !this._messages.some((m) => m.role === 'user');
+    if (isFirstUserMessage || this._drawer?.isKvkkBannerVisible()) {
+      markKvkkShown(this.config.accountId);
+      this._drawer?.hideKvkkBanner();
+    }
+
     ga.trackMessageSent();
     // Track conversation start on first user message in a new thread
     const hasUserMessages = this._messages.some((m) => m.role === 'user');

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -253,7 +253,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       if (config.headerAvatarUrl === undefined) {
         config.headerAvatarUrl = config.pillLauncher.avatarUrl;
       }
-      this._pillLauncherApply = () => kit.apply();
+      this._pillLauncherApply = () => kit.apply(this._shadow ?? undefined);
     }
 
     // Create Shadow DOM for CSS isolation

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -1,5 +1,6 @@
 import type { BaseWidgetConfig, ActionPayload } from '../common/types.js';
 import type { UnknownActionPolicy } from '../common/config-schema.js';
+import type { PillLauncherOptions } from '../common/pill-launcher.js';
 import type { UISpecDomRegistry, UISpecRendererOverrides } from '../common/renderer/index.js';
 
 export interface ChatWidgetConfig extends BaseWidgetConfig {
@@ -24,8 +25,16 @@ export interface ChatWidgetConfig extends BaseWidgetConfig {
    * Launcher image URL — renders the launcher as a full-size image button
    * (no circular background, no padding). The image fills the entire button.
    * Takes precedence over launcherSvg when set.
+   * Ignored when `pillLauncher` is set (pill derives `launcherImageUrl` from `pillLauncher.avatarUrl`).
    */
   launcherImageUrl?: string;
+
+  /**
+   * Declarative pill-shaped floating launcher (label + avatar). The widget calls
+   * `makePillLauncher` and `apply()` internally after mount — no host `apply()` needed.
+   * Floating variant only; omit manual `launcherImageUrl` when using this.
+   */
+  pillLauncher?: PillLauncherOptions;
 
   /** Tooltip text shown on launcher hover. */
   launcherTooltip?: string;

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -148,3 +148,6 @@ export type {
 
 export { getSuggestedSearchKeywords, getSuggestedSearchKeywordsText } from './suggested-search-keywords.js';
 export type { SuggestedSearchKeywordSource } from './suggested-search-keywords.js';
+
+export { makePillLauncher } from './pill-launcher.js';
+export type { PillLauncherOptions, PillLauncherKit } from './pill-launcher.js';

--- a/src/common/overlay.ts
+++ b/src/common/overlay.ts
@@ -115,7 +115,8 @@ export interface OverlayQNAOptions {
   renderer?: QNAWidgetConfig['renderer'];
   /**
    * Q&A panel heading (e.g. "Koçtaş'a Sor"). Independent from `chat.headerTitle`.
-   * If omitted, overlay falls back to `headingTitle` then `chat.headerTitle`.
+   * If omitted, falls back to the deprecated `headingTitle` field.
+   * Set this explicitly — it does not inherit from `chat.headerTitle`.
    */
   headerTitle?: string;
   /** @deprecated Use `headerTitle` */
@@ -400,8 +401,7 @@ class OverlayWidgetsRuntime implements OverlayWidgetsController {
           }
           if (this.options.qna?.i18n !== undefined) qnaConfig.i18n = this.options.qna.i18n;
           if (this.options.qna?.renderer !== undefined) qnaConfig.renderer = this.options.qna.renderer;
-          const qnaHeading =
-            this.options.qna?.headerTitle ?? this.options.qna?.headingTitle ?? this.options.chat?.headerTitle;
+          const qnaHeading = this.options.qna?.headerTitle ?? this.options.qna?.headingTitle;
           if (qnaHeading !== undefined) qnaConfig.headerTitle = qnaHeading;
           await qna.init(qnaConfig);
           this._qna = qna;

--- a/src/common/overlay.ts
+++ b/src/common/overlay.ts
@@ -401,9 +401,7 @@ class OverlayWidgetsRuntime implements OverlayWidgetsController {
           if (this.options.qna?.i18n !== undefined) qnaConfig.i18n = this.options.qna.i18n;
           if (this.options.qna?.renderer !== undefined) qnaConfig.renderer = this.options.qna.renderer;
           const qnaHeading =
-            this.options.qna?.headerTitle ??
-            this.options.qna?.headingTitle ??
-            this.options.chat?.headerTitle;
+            this.options.qna?.headerTitle ?? this.options.qna?.headingTitle ?? this.options.chat?.headerTitle;
           if (qnaHeading !== undefined) qnaConfig.headerTitle = qnaHeading;
           await qna.init(qnaConfig);
           this._qna = qna;

--- a/src/common/overlay.ts
+++ b/src/common/overlay.ts
@@ -111,6 +111,13 @@ export interface OverlayQNAOptions {
   i18n?: QNAWidgetConfig['i18n'];
   /** UISpec renderer overrides for QNA components. */
   renderer?: QNAWidgetConfig['renderer'];
+  /**
+   * Q&A panel heading (e.g. "Koçtaş'a Sor"). Independent from `chat.headerTitle`.
+   * If omitted, overlay falls back to `headingTitle` then `chat.headerTitle`.
+   */
+  headerTitle?: string;
+  /** @deprecated Use `headerTitle` */
+  headingTitle?: string;
 }
 
 export interface OverlaySimRelOptions {
@@ -388,6 +395,11 @@ class OverlayWidgetsRuntime implements OverlayWidgetsController {
           }
           if (this.options.qna?.i18n !== undefined) qnaConfig.i18n = this.options.qna.i18n;
           if (this.options.qna?.renderer !== undefined) qnaConfig.renderer = this.options.qna.renderer;
+          const qnaHeading =
+            this.options.qna?.headerTitle ??
+            this.options.qna?.headingTitle ??
+            this.options.chat?.headerTitle;
+          if (qnaHeading !== undefined) qnaConfig.headerTitle = qnaHeading;
           await qna.init(qnaConfig);
           this._qna = qna;
         } else {

--- a/src/common/overlay.ts
+++ b/src/common/overlay.ts
@@ -100,6 +100,8 @@ export interface OverlayChatOptions {
   renderer?: ChatWidgetConfig['renderer'];
   /** When true, allow full product details in the assistant side panel; default is chat summary only. */
   productDetailsExtended?: boolean;
+  /** Pill launcher — forwarded to `chat.pillLauncher` (applied inside GengageChat). */
+  pillLauncher?: ChatWidgetConfig['pillLauncher'];
 }
 
 export interface OverlayQNAOptions {
@@ -309,6 +311,9 @@ class OverlayWidgetsRuntime implements OverlayWidgetsController {
     if (this.options.locale !== undefined) config.locale = this.options.locale;
     if (this.options.pricing !== undefined) config.pricing = this.options.pricing;
     if (this.options.chat?.mountTarget !== undefined) config.mountTarget = this.options.chat.mountTarget;
+    if (this.options.chat?.pillLauncher !== undefined) {
+      config.pillLauncher = this.options.chat.pillLauncher;
+    }
     if (this.options.chat?.launcherImageUrl !== undefined) config.launcherImageUrl = this.options.chat.launcherImageUrl;
     else if (this.options.chat?.launcherSvg !== undefined) config.launcherSvg = this.options.chat.launcherSvg;
     if (this.options.chat?.headerTitle !== undefined) config.headerTitle = this.options.chat.headerTitle;

--- a/src/common/pill-launcher.ts
+++ b/src/common/pill-launcher.ts
@@ -44,8 +44,11 @@ export interface PillLauncherKit {
    * Injects pill CSS into the widget shadow root, fixes the header avatar
    * class, and appends the text label span to the launcher button.
    * Retries via requestAnimationFrame for up to ~1.5 s.
+   *
+   * Pass the widget's shadow root when it is available to avoid a global DOM
+   * scan — required when multiple GengageChat instances share the same page.
    */
-  apply(): Promise<void>;
+  apply(targetShadow?: ShadowRoot): Promise<void>;
 }
 
 export function makePillLauncher(options: PillLauncherOptions): PillLauncherKit {
@@ -88,11 +91,11 @@ button[data-gengage-part="chat-launcher-button"] {
   justify-content: space-between !important;
   gap: 12px !important;
   border-radius: 999px !important;
-  border: 1px solid color-mix(in srgb, var(--pill-secondary) 6%, white) !important;
+  border: 1px solid color-mix(in srgb, var(--pill-primary) 18%, white) !important;
   background: #ffffff !important;
   color: var(--pill-secondary) !important;
   box-shadow:
-    0 18px 46px color-mix(in srgb, var(--pill-secondary) 17%, transparent),
+    0 18px 46px color-mix(in srgb, var(--pill-primary) 18%, transparent),
     0 4px 14px color-mix(in srgb, var(--pill-secondary) 8%, transparent) !important;
   overflow: visible !important;
 }
@@ -100,7 +103,7 @@ button[data-gengage-part="chat-launcher-button"] {
 button[data-gengage-part="chat-launcher-button"]:hover {
   transform: translateY(-1px) !important;
   box-shadow:
-    0 22px 52px color-mix(in srgb, var(--pill-secondary) 22%, transparent),
+    0 22px 52px color-mix(in srgb, var(--pill-primary) 24%, transparent),
     0 6px 18px color-mix(in srgb, var(--pill-secondary) 12%, transparent) !important;
 }
 
@@ -168,20 +171,28 @@ button[data-gengage-part="chat-launcher-button"] img {
     root.appendChild(style);
   };
 
+  const escapedClassName = CSS.escape(labelClassName);
+
   const applyOnce = (root: ShadowRoot): boolean => {
     injectStyle(root);
 
     const launcher = root.querySelector('[data-gengage-part="chat-launcher-button"]');
     if (!(launcher instanceof HTMLButtonElement)) return false;
 
-    // When launcherImageUrl !== headerAvatarUrl the widget applies a logo class
-    // that breaks circular treatment on the header avatar — remove it.
+    // Only strip the logo class when the header and launcher show the same image.
+    // When headerAvatarUrl was explicitly set to a different asset (e.g. a rectangular
+    // brand logo), the logo class is intentional and must be preserved.
     const headerAvatar = root.querySelector('[data-gengage-part="chat-header-avatar"]');
     if (headerAvatar instanceof HTMLImageElement) {
-      headerAvatar.classList.remove('gengage-chat-header-avatar--logo');
+      const launcherImg = root.querySelector<HTMLImageElement>(
+        '[data-gengage-part="chat-launcher-button"] img',
+      );
+      if (!launcherImg || headerAvatar.src === launcherImg.src) {
+        headerAvatar.classList.remove('gengage-chat-header-avatar--logo');
+      }
     }
 
-    if (launcher.querySelector(`.${labelClassName}`)) return true;
+    if (launcher.querySelector(`.${escapedClassName}`)) return true;
 
     launcher.setAttribute('aria-label', label);
     const labelEl = document.createElement('span');
@@ -191,8 +202,21 @@ button[data-gengage-part="chat-launcher-button"] img {
     return true;
   };
 
-  const apply = async (): Promise<void> => {
-    // Inject style early so the first paint never shows the default circle FAB
+  const apply = async (targetShadow?: ShadowRoot): Promise<void> => {
+    // When the caller passes the widget's own shadow root, use it directly and
+    // skip the global DOM scan — this prevents cross-instance interference when
+    // multiple GengageChat widgets share the same page.
+    if (targetShadow) {
+      injectStyle(targetShadow);
+      await Promise.resolve();
+      for (let frame = 0; frame < 90; frame++) {
+        if (applyOnce(targetShadow)) return;
+        await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      }
+      return;
+    }
+
+    // Fallback: scan the document for a matching chat shadow host (standalone use).
     const earlyHost = findShadowHost();
     if (earlyHost?.shadowRoot) injectStyle(earlyHost.shadowRoot);
 

--- a/src/common/pill-launcher.ts
+++ b/src/common/pill-launcher.ts
@@ -2,14 +2,10 @@
  * makePillLauncher — creates a pill-shaped chat launcher that combines an
  * avatar image with a text label, replacing the default circular FAB.
  *
- * When a client does not supply a custom `launcherImageUrl`, use this helper
- * to build a branded pill from the assistant's avatar instead:
- *
- *   const pill = makePillLauncher({ label: "Teknosa'ya Sor", avatarUrl, primaryColor: '#f58220', secondaryColor: '#0c0b37' });
- *   const controller = await initOverlayWidgets({
- *     chat: { launcherImageUrl: pill.launcherImageUrl, headerAvatarUrl: avatarUrl, ... },
+
  *   });
- *   await pill.apply();
+ *
+ * Or call `makePillLauncher` + `apply()` manually when you need custom control.
  */
 
 export interface PillLauncherOptions {

--- a/src/common/pill-launcher.ts
+++ b/src/common/pill-launcher.ts
@@ -1,0 +1,217 @@
+/**
+ * makePillLauncher — creates a pill-shaped chat launcher that combines an
+ * avatar image with a text label, replacing the default circular FAB.
+ *
+ * When a client does not supply a custom `launcherImageUrl`, use this helper
+ * to build a branded pill from the assistant's avatar instead:
+ *
+ *   const pill = makePillLauncher({ label: "Teknosa'ya Sor", avatarUrl, primaryColor: '#f58220', secondaryColor: '#0c0b37' });
+ *   const controller = await initOverlayWidgets({
+ *     chat: { launcherImageUrl: pill.launcherImageUrl, headerAvatarUrl: avatarUrl, ... },
+ *   });
+ *   await pill.apply();
+ */
+
+export interface PillLauncherOptions {
+  /** Text label shown beside the avatar inside the pill */
+  label: string;
+  /** Avatar image URL — also used as `launcherImageUrl` to activate image-mode */
+  avatarUrl: string;
+  /** Brand primary color — used for border and hover effects */
+  primaryColor: string;
+  /** Dark text / shadow color for the label and drop shadow (default: '#111827') */
+  secondaryColor?: string;
+  /** CSS font-family string for the label text */
+  fontFamily?: string;
+  /** CSS class name injected on the label span (default: 'gengage-pill-launcher-label') */
+  labelClassName?: string;
+  /** id for the <style> tag injected into the shadow root (default: 'gengage-pill-launcher-style') */
+  styleId?: string;
+  /** Mobile breakpoint in px (default: 768) */
+  mobileBreakpoint?: number;
+  /** Desktop pill width (default: '188px') */
+  desktopWidth?: string;
+  /** Desktop pill height (default: '60px') */
+  desktopHeight?: string;
+  /** Avatar icon diameter (default: '46px') */
+  iconSize?: string;
+}
+
+export interface PillLauncherKit {
+  /**
+   * Pass as `chat.launcherImageUrl` to `initOverlayWidgets`.
+   * Equals `avatarUrl` — activates image-mode on the launcher button.
+   */
+  launcherImageUrl: string;
+  /**
+   * Call after `initOverlayWidgets` resolves.
+   * Injects pill CSS into the widget shadow root, fixes the header avatar
+   * class, and appends the text label span to the launcher button.
+   * Retries via requestAnimationFrame for up to ~1.5 s.
+   */
+  apply(): Promise<void>;
+}
+
+export function makePillLauncher(options: PillLauncherOptions): PillLauncherKit {
+  const {
+    label,
+    avatarUrl,
+    primaryColor,
+    secondaryColor = '#111827',
+    fontFamily = 'inherit',
+    labelClassName = 'gengage-pill-launcher-label',
+    styleId = 'gengage-pill-launcher-style',
+    mobileBreakpoint = 768,
+    desktopWidth = '188px',
+    desktopHeight = '60px',
+    iconSize = '46px',
+  } = options;
+
+  const mobileWidth = `${parseInt(desktopWidth, 10) - 14}px`;
+  const mobileHeight = `${parseInt(desktopHeight, 10) - 4}px`;
+  const mobileIconSize = `${parseInt(iconSize, 10) - 4}px`;
+
+  const css = `
+:host {
+  --pill-primary: ${primaryColor};
+  --pill-secondary: ${secondaryColor};
+  --pill-font: ${fontFamily};
+}
+
+button[data-gengage-part="chat-launcher-button"] {
+  box-sizing: border-box;
+  width: ${desktopWidth} !important;
+  min-width: ${desktopWidth} !important;
+  max-width: ${desktopWidth} !important;
+  height: ${desktopHeight} !important;
+  min-height: ${desktopHeight} !important;
+  padding: 6px 7px 6px 22px !important;
+  display: inline-flex !important;
+  flex-direction: row-reverse !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  gap: 12px !important;
+  border-radius: 999px !important;
+  border: 1px solid color-mix(in srgb, var(--pill-secondary) 6%, white) !important;
+  background: #ffffff !important;
+  color: var(--pill-secondary) !important;
+  box-shadow:
+    0 18px 46px color-mix(in srgb, var(--pill-secondary) 17%, transparent),
+    0 4px 14px color-mix(in srgb, var(--pill-secondary) 8%, transparent) !important;
+  overflow: visible !important;
+}
+
+button[data-gengage-part="chat-launcher-button"]:hover {
+  transform: translateY(-1px) !important;
+  box-shadow:
+    0 22px 52px color-mix(in srgb, var(--pill-secondary) 22%, transparent),
+    0 6px 18px color-mix(in srgb, var(--pill-secondary) 12%, transparent) !important;
+}
+
+.${labelClassName} {
+  color: var(--pill-secondary);
+  font: 500 15px/1.05 var(--pill-font);
+  letter-spacing: -0.02em;
+  white-space: nowrap;
+  flex: 0 0 auto;
+  pointer-events: none;
+}
+
+button[data-gengage-part="chat-launcher-button"] img {
+  width: ${iconSize} !important;
+  height: ${iconSize} !important;
+  flex: 0 0 ${iconSize} !important;
+  border-radius: 999px;
+  object-fit: cover;
+  object-position: center;
+  background: transparent;
+  border: 0 !important;
+  box-shadow: none !important;
+}
+
+@media (max-width: ${mobileBreakpoint}px) {
+  button[data-gengage-part="chat-launcher-button"] {
+    width: ${mobileWidth} !important;
+    min-width: ${mobileWidth} !important;
+    max-width: ${mobileWidth} !important;
+    height: ${mobileHeight} !important;
+    min-height: ${mobileHeight} !important;
+    padding-left: 20px !important;
+    padding-right: 7px !important;
+  }
+
+  .${labelClassName} {
+    font-size: 14px;
+  }
+
+  button[data-gengage-part="chat-launcher-button"] img {
+    width: ${mobileIconSize} !important;
+    height: ${mobileIconSize} !important;
+    flex-basis: ${mobileIconSize} !important;
+  }
+}
+`.trim();
+
+  const findShadowHost = (): HTMLElement | null => {
+    for (const el of document.querySelectorAll('[data-gengage-widget]')) {
+      if (!(el instanceof HTMLElement)) continue;
+      const sr = el.shadowRoot;
+      if (!sr) continue;
+      if (sr.querySelector('[data-gengage-part="chat-launcher-button"]') || sr.querySelector('.gengage-chat-root')) {
+        return el;
+      }
+    }
+    return null;
+  };
+
+  const injectStyle = (root: ShadowRoot): void => {
+    if (root.getElementById(styleId)) return;
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = css;
+    root.appendChild(style);
+  };
+
+  const applyOnce = (root: ShadowRoot): boolean => {
+    injectStyle(root);
+
+    const launcher = root.querySelector('[data-gengage-part="chat-launcher-button"]');
+    if (!(launcher instanceof HTMLButtonElement)) return false;
+
+    // When launcherImageUrl !== headerAvatarUrl the widget applies a logo class
+    // that breaks circular treatment on the header avatar — remove it.
+    const headerAvatar = root.querySelector('[data-gengage-part="chat-header-avatar"]');
+    if (headerAvatar instanceof HTMLImageElement) {
+      headerAvatar.classList.remove('gengage-chat-header-avatar--logo');
+    }
+
+    if (launcher.querySelector(`.${labelClassName}`)) return true;
+
+    launcher.setAttribute('aria-label', label);
+    const labelEl = document.createElement('span');
+    labelEl.className = labelClassName;
+    labelEl.textContent = label;
+    launcher.appendChild(labelEl);
+    return true;
+  };
+
+  const apply = async (): Promise<void> => {
+    // Inject style early so the first paint never shows the default circle FAB
+    const earlyHost = findShadowHost();
+    if (earlyHost?.shadowRoot) injectStyle(earlyHost.shadowRoot);
+
+    await Promise.resolve();
+
+    for (let frame = 0; frame < 90; frame++) {
+      const host = findShadowHost();
+      const root = host?.shadowRoot ?? null;
+      if (root) {
+        injectStyle(root);
+        if (applyOnce(root)) return;
+      }
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    }
+  };
+
+  return { launcherImageUrl: avatarUrl, apply };
+}

--- a/src/common/ui-theme.ts
+++ b/src/common/ui-theme.ts
@@ -18,7 +18,8 @@ export const DEFAULT_WIDGET_THEME_TOKENS: WidgetTheme = {
   '--gengage-chat-input-height': '48px',
 
   '--gengage-qna-pill-radius': '999px' /* roundedness-full */,
-  '--gengage-qna-input-radius': '0.75rem' /* md roundedness */,
+  /** Rounded rect (not full pill) — matches `src/qna/components/qna.css` */
+  '--gengage-qna-input-radius': '12px',
 
   '--gengage-simrel-card-radius': '0.75rem' /* md roundedness */,
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export {
   extractSkuFromUrl,
   autoDetectPageContext,
   configureConnectionWarning,
+  makePillLauncher,
 } from './common/index.js';
 
 // Types (re-exported for consumers who want to type their own code)
@@ -133,6 +134,8 @@ export type {
   VoiceInputOptions,
   DetectablePageType,
   PageDetectionRule,
+  PillLauncherOptions,
+  PillLauncherKit,
 } from './common/index.js';
 
 export type { ChatWidgetConfig, ChatMessage, ChatSession, ChatI18n, ChatRendererConfig } from './chat/index.js';

--- a/src/qna/components/qna.css
+++ b/src/qna/components/qna.css
@@ -1,6 +1,10 @@
 @import '../../design-system/index.css';
 
 .gengage-qna-container {
+  /* Spacing when embedded in merchant layout (overridable) */
+  margin-top: var(--gengage-qna-container-margin-top, 16px);
+  margin-bottom: var(--gengage-qna-container-margin-bottom, 32px);
+
   font-family: var(
     --gengage-font-family,
     'Plus Jakarta Sans',
@@ -14,29 +18,41 @@
   color: var(--text-primary);
   position: relative;
 
-  /* Semantic color tokens (overridable by customers) */
+  /* Semantic color tokens (overridable by customers) — default: light panel + outline pills */
   --_gengage-border-color: var(--border-default);
   --_gengage-text-primary: var(--text-primary);
   --_gengage-text-secondary: var(--text-secondary);
-  --_gengage-qna-panel-surface: var(--gengage-qna-panel-bg, var(--surface-card));
-  --_gengage-qna-icon-color: var(--gengage-qna-icon-color, var(--text-muted));
+  --_gengage-qna-panel-surface: var(--gengage-qna-panel-bg, #f7f7f9);
+  --_gengage-qna-icon-color: var(--gengage-qna-icon-color, var(--client-primary));
   --_gengage-qna-transition-overlay: color-mix(in srgb, var(--surface-card) 78%, transparent);
-  --_gengage-qna-pill-bg: var(--gengage-qna-pill-bg, var(--ds-button-primary-bg));
-  --_gengage-qna-pill-bg-hover: var(--gengage-qna-pill-bg-hover, var(--ds-button-primary-bg-hover));
-  --_gengage-qna-pill-fg: var(--gengage-qna-pill-fg, var(--ds-button-primary-fg));
-  --_gengage-qna-pill-border: var(--gengage-qna-pill-border, var(--ds-button-primary-border));
-  --_gengage-qna-pill-border-hover: var(--gengage-qna-pill-border-hover, var(--_gengage-qna-pill-border));
-  --_gengage-qna-input-bg: var(--gengage-qna-input-bg, var(--ds-input-bg));
-  --_gengage-qna-input-border: var(--gengage-qna-input-border, var(--ds-input-border));
+  --_gengage-qna-pill-bg: var(--gengage-qna-pill-bg, #fff);
+  --_gengage-qna-pill-bg-hover: var(
+    --gengage-qna-pill-bg-hover,
+    color-mix(in srgb, var(--client-primary) 10%, white)
+  );
+  --_gengage-qna-pill-fg: var(--gengage-qna-pill-fg, var(--client-primary));
+  --_gengage-qna-pill-border: var(
+    --gengage-qna-pill-border,
+    color-mix(in srgb, var(--client-primary) 64%, white)
+  );
+  --_gengage-qna-pill-border-hover: var(
+    --gengage-qna-pill-border-hover,
+    color-mix(in srgb, var(--client-primary) 78%, white)
+  );
+  --_gengage-qna-input-bg: var(--gengage-qna-input-bg, #fff);
+  --_gengage-qna-input-border: var(
+    --gengage-qna-input-border,
+    color-mix(in srgb, var(--client-primary) 58%, white)
+  );
   --_gengage-qna-action-icon-bg-hover: var(
     --gengage-qna-action-icon-bg-hover,
-    color-mix(in srgb, var(--client-primary) 10%, transparent)
+    color-mix(in srgb, var(--client-primary) 12%, white)
   );
-  --_gengage-qna-clear-color: var(--gengage-qna-clear-color, var(--text-muted));
+  --_gengage-qna-clear-color: var(--gengage-qna-clear-color, var(--client-primary));
   --_gengage-qna-send-color: var(--gengage-qna-send-color, var(--client-primary));
   --_gengage-qna-send-color-disabled: var(
     --gengage-qna-send-color-disabled,
-    color-mix(in srgb, var(--text-muted) 60%, transparent)
+    color-mix(in srgb, var(--client-primary) 36%, #b3b8c8)
   );
   --_gengage-qna-action-icon-size: var(--gengage-qna-action-icon-size, 20px);
 }
@@ -45,13 +61,27 @@
   position: relative;
   z-index: 0;
   isolation: isolate;
+  display: flex;
+  flex-direction: column;
   background: var(--_gengage-qna-panel-surface);
-  border: 1px solid var(--_gengage-border-color);
-  border-radius: var(--gengage-qna-panel-radius, var(--ds-panel-radius));
-  padding: 16px 16px 14px;
-  margin-bottom: var(--gengage-qna-panel-margin-bottom, 18px);
-  margin-top: var(--gengage-qna-panel-margin-top, 18px);
-  box-shadow: var(--ds-panel-shadow);
+  border: var(--gengage-qna-panel-border, 1px solid var(--_gengage-border-color));
+  border-radius: var(--gengage-qna-panel-radius, 14px);
+  padding: var(--gengage-qna-panel-padding, 18px 20px 24px);
+  margin-bottom: var(--gengage-qna-panel-margin-bottom, 0);
+  margin-top: var(--gengage-qna-panel-margin-top, 0);
+  box-shadow: var(
+    --gengage-qna-panel-shadow,
+    0 2px 14px color-mix(in srgb, var(--_gengage-text-primary) 7%, transparent),
+    0 1px 2px color-mix(in srgb, var(--_gengage-text-primary) 5%, transparent)
+  );
+}
+
+/* Static heading (outside uispec) stays above streamed uispec blocks */
+.gengage-qna-panel > .gengage-qna-heading {
+  order: 0;
+}
+.gengage-qna-panel > .gengage-qna-uispec {
+  order: 1;
 }
 
 /* Keep pills/input below the transition overlay (transform on buttons creates stacking contexts) */
@@ -67,7 +97,18 @@
 .gengage-qna-uispec {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--gengage-qna-uispec-gap, 12px);
+}
+
+/* Stable visual order when backend emits children in a different sequence */
+.gengage-qna-uispec > .gengage-qna-heading {
+  order: 0;
+}
+.gengage-qna-uispec > .gengage-qna-input-wrapper {
+  order: 1;
+}
+.gengage-qna-uispec > .gengage-qna-buttons {
+  order: 2;
 }
 
 .gengage-qna-uispec > * {
@@ -89,21 +130,22 @@
 .gengage-qna-buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 4px 0 10px;
+  gap: var(--gengage-qna-buttons-gap, 10px);
+  padding: var(--gengage-qna-buttons-padding, 2px 0 2px);
+  align-content: flex-start;
 }
 
 .gengage-qna-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 40px;
-  padding: 8px 14px;
+  min-height: var(--gengage-qna-button-min-height, 34px);
+  padding: var(--gengage-qna-button-padding, 6px 12px);
   border: 1px solid var(--_gengage-qna-pill-border);
   border-radius: var(--radius-pill, var(--gengage-qna-pill-radius, 999px));
   background: var(--_gengage-qna-pill-bg);
   color: var(--_gengage-qna-pill-fg);
-  font-size: 13px;
+  font-size: var(--gengage-qna-button-font-size, 14px);
   font-weight: 700;
   font-family: inherit;
   cursor: pointer;
@@ -113,7 +155,7 @@
     color 0.14s ease,
     transform 0.12s ease;
   text-align: left;
-  line-height: 1.25;
+  line-height: 1.3;
 }
 
 .gengage-qna-button:hover {
@@ -134,13 +176,13 @@
 .gengage-qna-cta {
   display: inline-flex;
   align-items: center;
-  min-height: 40px;
-  padding: 8px 14px;
+  min-height: var(--gengage-qna-button-min-height, 34px);
+  padding: var(--gengage-qna-button-padding, 6px 12px);
   border: 1px solid var(--ds-button-secondary-border);
   border-radius: var(--radius-pill, var(--gengage-qna-pill-radius, 999px));
   background: var(--ds-button-secondary-bg);
   color: var(--ds-button-secondary-fg);
-  font-size: 13px;
+  font-size: var(--gengage-qna-button-font-size, 14px);
   font-weight: 700;
   font-family: inherit;
   cursor: pointer;
@@ -162,7 +204,8 @@
 }
 
 .gengage-qna-input-wrapper {
-  padding: 6px 0 0;
+  padding: var(--gengage-qna-input-wrapper-padding, 0);
+  margin-bottom: var(--gengage-qna-input-wrapper-margin-bottom, 14px);
 }
 
 .gengage-qna-input-combo {
@@ -172,9 +215,9 @@
   align-items: center;
   min-height: 48px;
   border: 1px solid var(--_gengage-qna-input-border);
-  border-radius: var(--gengage-qna-input-radius, var(--ds-input-radius));
+  border-radius: var(--gengage-qna-input-radius, 12px);
   background: var(--_gengage-qna-input-bg);
-  box-shadow: var(--ds-input-highlight);
+  box-shadow: var(--gengage-qna-input-inner-shadow, var(--ds-input-highlight));
   overflow: hidden;
   transition:
     border-color 0.14s ease,
@@ -221,7 +264,8 @@
   padding: 0 10px 0 40px;
   border: none;
   border-radius: 0;
-  font-size: 15px;
+  font-size: var(--gengage-qna-input-font-size, 14px);
+  font-weight: var(--gengage-qna-input-font-weight, 500);
   font-family: inherit;
   outline: none;
   background: transparent;
@@ -229,6 +273,7 @@
 }
 
 .gengage-qna-input::placeholder {
+  color: var(--gengage-qna-input-placeholder-color, #6b7280);
   transition: opacity 0.18s ease;
 }
 
@@ -325,10 +370,12 @@
 }
 
 .gengage-qna-heading {
-  font-size: 1.04em;
-  font-weight: 700;
-  margin: 0 0 6px;
-  color: var(--_gengage-text-primary);
+  font-size: var(--gengage-qna-heading-font-size, clamp(16px, 1.15vw, 19px));
+  line-height: var(--gengage-qna-heading-line-height, 1.3);
+  letter-spacing: var(--gengage-qna-heading-letter-spacing, -0.012em);
+  font-weight: var(--gengage-qna-heading-font-weight, 700);
+  margin: var(--gengage-qna-heading-margin, 0 0 8px);
+  color: var(--gengage-qna-heading-color, var(--_gengage-text-primary));
 }
 
 .gengage-qna-loading {
@@ -366,6 +413,21 @@
   40% {
     opacity: 1;
     transform: scale(1);
+  }
+}
+
+@media (max-width: 900px) {
+  .gengage-qna-panel {
+    padding: var(--gengage-qna-panel-padding-tablet, 14px 16px 18px);
+  }
+
+  .gengage-qna-uispec {
+    gap: var(--gengage-qna-uispec-gap-tablet, 12px);
+  }
+
+  .gengage-qna-uispec > .gengage-qna-buttons {
+    padding-top: var(--gengage-qna-buttons-padding-top-tablet, 2px);
+    gap: var(--gengage-qna-buttons-gap-tablet, 8px);
   }
 }
 

--- a/src/qna/components/qna.css
+++ b/src/qna/components/qna.css
@@ -26,24 +26,15 @@
   --_gengage-qna-icon-color: var(--gengage-qna-icon-color, var(--client-primary));
   --_gengage-qna-transition-overlay: color-mix(in srgb, var(--surface-card) 78%, transparent);
   --_gengage-qna-pill-bg: var(--gengage-qna-pill-bg, #fff);
-  --_gengage-qna-pill-bg-hover: var(
-    --gengage-qna-pill-bg-hover,
-    color-mix(in srgb, var(--client-primary) 10%, white)
-  );
+  --_gengage-qna-pill-bg-hover: var(--gengage-qna-pill-bg-hover, color-mix(in srgb, var(--client-primary) 10%, white));
   --_gengage-qna-pill-fg: var(--gengage-qna-pill-fg, var(--client-primary));
-  --_gengage-qna-pill-border: var(
-    --gengage-qna-pill-border,
-    color-mix(in srgb, var(--client-primary) 64%, white)
-  );
+  --_gengage-qna-pill-border: var(--gengage-qna-pill-border, color-mix(in srgb, var(--client-primary) 64%, white));
   --_gengage-qna-pill-border-hover: var(
     --gengage-qna-pill-border-hover,
     color-mix(in srgb, var(--client-primary) 78%, white)
   );
   --_gengage-qna-input-bg: var(--gengage-qna-input-bg, #fff);
-  --_gengage-qna-input-border: var(
-    --gengage-qna-input-border,
-    color-mix(in srgb, var(--client-primary) 58%, white)
-  );
+  --_gengage-qna-input-border: var(--gengage-qna-input-border, color-mix(in srgb, var(--client-primary) 58%, white));
   --_gengage-qna-action-icon-bg-hover: var(
     --gengage-qna-action-icon-bg-hover,
     color-mix(in srgb, var(--client-primary) 12%, white)

--- a/src/qna/components/renderUISpec.ts
+++ b/src/qna/components/renderUISpec.ts
@@ -142,12 +142,19 @@ const DEFAULT_QNA_UI_SPEC_REGISTRY: QNAUISpecRegistry = {
     return renderTextInput(options);
   },
 
-  QuestionHeading: ({ element }) => {
+  QuestionHeading: ({ element, context }) => {
     const heading = document.createElement('h3');
     heading.className = 'gengage-qna-heading';
     heading.dataset['gengagePart'] = 'qna-heading';
-    const text = element.props?.['text'];
-    heading.textContent = typeof text === 'string' ? text : '';
+    const fromStream = element.props?.['text'];
+    const override = context.headingTitleOverride;
+    const text =
+      typeof override === 'string' && override.trim().length > 0
+        ? override
+        : typeof fromStream === 'string'
+          ? fromStream
+          : '';
+    heading.textContent = text;
     return heading;
   },
 

--- a/src/qna/index.ts
+++ b/src/qna/index.ts
@@ -129,6 +129,14 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
     this._abortController = null;
   }
 
+  /** `headerTitle` wins over deprecated `headingTitle`. */
+  private _resolvedQnaHeaderTitle(): string | undefined {
+    const raw = this.config.headerTitle ?? this.config.headingTitle;
+    if (typeof raw !== 'string') return undefined;
+    const t = raw.trim();
+    return t.length > 0 ? t : undefined;
+  }
+
   /** Clean up TextInput placeholder rotation timers to prevent interval leaks. */
   private _cleanupTextInputTimers(): void {
     if (!this._contentEl) return;
@@ -211,11 +219,15 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
 
       const hasQuestionHeading = this._specIncludesType(result.uiSpecs, 'QuestionHeading');
 
+      const staticHeadingText =
+        this._resolvedQnaHeaderTitle() ??
+        (this.config.showStaticQuestion && this.config.staticQuestionText ? this.config.staticQuestionText : undefined);
+
       // Render heading if configured and backend didn't provide one
-      if (!hasQuestionHeading && this.config.showStaticQuestion && this.config.staticQuestionText) {
+      if (!hasQuestionHeading && staticHeadingText) {
         const heading = document.createElement('h3');
         heading.className = 'gengage-qna-heading';
-        heading.textContent = this.config.staticQuestionText;
+        heading.textContent = staticHeadingText;
         panel.appendChild(heading);
       }
 
@@ -237,6 +249,10 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
         onAction: this._actionHandler,
         i18n: this._i18n,
       };
+      const resolvedHeader = this._resolvedQnaHeaderTitle();
+      if (resolvedHeader !== undefined) {
+        renderContext.headingTitleOverride = resolvedHeader;
+      }
       if (!this.config.hideButtonRowCta) {
         renderContext.onOpenChat = this._openChatHandler;
         if (this.config.ctaText !== undefined) renderContext.ctaText = this.config.ctaText;
@@ -264,7 +280,7 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
 
       const shouldRenderStandaloneInput = !this._specIncludesType(nonEmptySpecs, 'TextInput');
       if (shouldRenderStandaloneInput) {
-        this._appendStandaloneInput(renderContext, effectivePlaceholders, panel);
+        this._insertStandaloneInputBeforePills(panel, renderContext, effectivePlaceholders);
       }
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') return;
@@ -300,6 +316,10 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
           i18n: this._i18n,
           onOpenChat: this._openChatHandler,
         };
+        const errHeader = this._resolvedQnaHeaderTitle();
+        if (errHeader !== undefined) {
+          fallbackContext.headingTitleOverride = errHeader;
+        }
         if (this.config.ctaText !== undefined) fallbackContext.ctaText = this.config.ctaText;
         this._appendStandaloneInput(fallbackContext, fallbackPlaceholders, errPanel);
       }
@@ -390,6 +410,49 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
       root: 'root',
       elements,
     };
+  }
+
+  /**
+   * Free-text field when the launcher stream has no TextInput. Must sit **above** the
+   * quick-question pills (heading → search → chips), not below — see `render` order above.
+   */
+  private _insertStandaloneInputBeforePills(
+    panel: HTMLElement,
+    context: QNAUISpecRenderContext,
+    placeholder?: string | string[],
+  ): void {
+    const inputSpec: UISpec = {
+      root: 'root',
+      elements: {
+        root: {
+          type: 'TextInput',
+          props: {
+            placeholder,
+          },
+        },
+      },
+    };
+    const standaloneRoot = this._renderUISpec(inputSpec, context);
+    const inputWrapper = standaloneRoot.querySelector('.gengage-qna-input-wrapper');
+    if (!inputWrapper) return;
+
+    const firstUispec = panel.querySelector('.gengage-qna-uispec');
+    const buttons = firstUispec?.querySelector(':scope > .gengage-qna-buttons');
+
+    if (firstUispec && buttons) {
+      firstUispec.insertBefore(inputWrapper, buttons);
+    } else if (firstUispec) {
+      const heading = firstUispec.querySelector(':scope > .gengage-qna-heading');
+      if (heading) {
+        heading.insertAdjacentElement('afterend', inputWrapper);
+      } else {
+        firstUispec.prepend(inputWrapper);
+      }
+    } else {
+      panel.appendChild(standaloneRoot);
+      return;
+    }
+    standaloneRoot.remove();
   }
 
   private _appendStandaloneInput(

--- a/src/qna/types.ts
+++ b/src/qna/types.ts
@@ -25,6 +25,17 @@ export interface QNAWidgetConfig extends BaseWidgetConfig {
   showStaticQuestion?: boolean;
   staticQuestionText?: string;
 
+  /**
+   * Title above the Q&A module (e.g. "Koçtaş'a Sor", "Teknosa'ya Sor").
+   * When set, overrides the stream `QuestionHeading` text from the backend.
+   * Overlay defaults: `qna.headerTitle` → `qna.headingTitle` (deprecated) → `chat.headerTitle`.
+   */
+  headerTitle?: string;
+  /**
+   * @deprecated Use `headerTitle` — same behavior.
+   */
+  headingTitle?: string;
+
   // -------------------------------------------------------------------------
   // Callbacks (alternative to event listeners)
   // -------------------------------------------------------------------------
@@ -57,6 +68,8 @@ export interface QNAUISpecRenderContext {
   ctaText?: string;
   inputPlaceholder?: string | string[];
   i18n: QNAI18n;
+  /** When set (from `QNAWidgetConfig.headerTitle` / `headingTitle`), replaces QuestionHeading `text` from the stream. */
+  headingTitleOverride?: string;
 }
 
 export type QNARendererConfig = UISpecRendererOverrides<QNAUISpecRenderContext>;

--- a/tests/kvkk-banner.test.ts
+++ b/tests/kvkk-banner.test.ts
@@ -1,5 +1,18 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createKvkkBanner } from '../src/chat/components/KvkkBanner.js';
+import { ChatDrawer } from '../src/chat/components/ChatDrawer.js';
+import { CHAT_I18N_TR } from '../src/chat/locales/index.js';
+
+function makeDrawer() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const drawer = new ChatDrawer(container, {
+    i18n: CHAT_I18N_TR,
+    onSend: vi.fn(),
+    onClose: vi.fn(),
+  });
+  return { drawer, container };
+}
 
 describe('KvkkBanner', () => {
   it('renders a banner with the provided HTML content', () => {
@@ -44,5 +57,45 @@ describe('KvkkBanner', () => {
     expect(btn).not.toBeNull();
     expect(btn?.getAttribute('aria-label')).toBe('Close privacy notice');
     expect(btn?.textContent).toBe('\u00D7');
+  });
+});
+
+describe('ChatDrawer.isKvkkBannerVisible', () => {
+  it('returns false when no banner has been shown', () => {
+    const { drawer } = makeDrawer();
+    expect(drawer.isKvkkBannerVisible()).toBe(false);
+  });
+
+  it('returns true after showKvkkBanner', () => {
+    const { drawer } = makeDrawer();
+    drawer.showKvkkBanner('<p>KVKK metni</p>', () => {});
+    expect(drawer.isKvkkBannerVisible()).toBe(true);
+  });
+
+  it('returns false after hideKvkkBanner', () => {
+    const { drawer } = makeDrawer();
+    drawer.showKvkkBanner('<p>KVKK metni</p>', () => {});
+    drawer.hideKvkkBanner();
+    expect(drawer.isKvkkBannerVisible()).toBe(false);
+  });
+
+  it('returns false after calling showKvkkBanner then dismiss callback', () => {
+    const { drawer } = makeDrawer();
+    drawer.showKvkkBanner('<p>KVKK metni</p>', () => {
+      drawer.hideKvkkBanner();
+    });
+    expect(drawer.isKvkkBannerVisible()).toBe(true);
+    drawer.hideKvkkBanner();
+    expect(drawer.isKvkkBannerVisible()).toBe(false);
+  });
+
+  it('replaces existing banner when showKvkkBanner called again', () => {
+    const { drawer, container } = makeDrawer();
+    drawer.showKvkkBanner('<p>First</p>', () => {});
+    drawer.showKvkkBanner('<p>Second</p>', () => {});
+    expect(drawer.isKvkkBannerVisible()).toBe(true);
+    // Only one banner should exist inside this drawer's slot
+    const slot = container.querySelector('[data-gengage-part="chat-kvkk-slot"]');
+    expect(slot?.childNodes.length).toBe(1);
   });
 });

--- a/tests/overlay.test.ts
+++ b/tests/overlay.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock widget constructors so overlay doesn't try to create real DOM/fetch
 vi.mock('../src/chat/index.js', () => ({
@@ -47,6 +47,8 @@ import {
   destroyOverlayWidgets,
   buildOverlayIdempotencyKey,
 } from '../src/common/overlay.js';
+import { GengageQNA } from '../src/qna/index.js';
+import { GengageChat } from '../src/chat/index.js';
 
 describe('overlay', () => {
   beforeEach(() => {
@@ -194,6 +196,83 @@ describe('overlay', () => {
 
       controller.closeChat();
       expect(controller.chat!.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('QNA headerTitle forwarding', () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it('passes qna.headerTitle directly to QNA init config', async () => {
+      await initOverlayWidgets({
+        accountId: 'qna-headertitle-direct',
+        middlewareUrl: 'https://example.com',
+        sku: 'SKU123',
+        qna: { headerTitle: "Koçtaş'a Sor" },
+      });
+
+      const qnaInstance = vi.mocked(GengageQNA).mock.instances[0] as Record<string, ReturnType<typeof vi.fn>>;
+      const initArg = qnaInstance['init'].mock.calls[0][0] as Record<string, unknown>;
+      expect(initArg['headerTitle']).toBe("Koçtaş'a Sor");
+    });
+
+    it('falls back to chat.headerTitle for QNA when qna.headerTitle is not set', async () => {
+      await initOverlayWidgets({
+        accountId: 'qna-headertitle-fallback',
+        middlewareUrl: 'https://example.com',
+        sku: 'SKU123',
+        chat: { headerTitle: "Boyner'e Sor" },
+      });
+
+      const qnaInstance = vi.mocked(GengageQNA).mock.instances[0] as Record<string, ReturnType<typeof vi.fn>>;
+      const initArg = qnaInstance['init'].mock.calls[0][0] as Record<string, unknown>;
+      expect(initArg['headerTitle']).toBe("Boyner'e Sor");
+    });
+
+    it('qna.headerTitle takes precedence over chat.headerTitle', async () => {
+      await initOverlayWidgets({
+        accountId: 'qna-headertitle-priority',
+        middlewareUrl: 'https://example.com',
+        sku: 'SKU123',
+        chat: { headerTitle: 'Chat Title' },
+        qna: { headerTitle: 'QNA Title' },
+      });
+
+      const qnaInstance = vi.mocked(GengageQNA).mock.instances[0] as Record<string, ReturnType<typeof vi.fn>>;
+      const initArg = qnaInstance['init'].mock.calls[0][0] as Record<string, unknown>;
+      expect(initArg['headerTitle']).toBe('QNA Title');
+    });
+
+    it('qna.headingTitle (deprecated) is used when headerTitle is absent', async () => {
+      await initOverlayWidgets({
+        accountId: 'qna-headertitle-deprecated',
+        middlewareUrl: 'https://example.com',
+        sku: 'SKU123',
+        qna: { headingTitle: 'Legacy Title' },
+      });
+
+      const qnaInstance = vi.mocked(GengageQNA).mock.instances[0] as Record<string, ReturnType<typeof vi.fn>>;
+      const initArg = qnaInstance['init'].mock.calls[0][0] as Record<string, unknown>;
+      expect(initArg['headerTitle']).toBe('Legacy Title');
+    });
+
+    it('forwards pillLauncher from chat options to GengageChat init config', async () => {
+      const pillLauncher = {
+        label: "Koçtaş'a Sor",
+        avatarUrl: 'https://example.com/logo.svg',
+        primaryColor: '#ec6e00',
+      };
+
+      await initOverlayWidgets({
+        accountId: 'pill-launcher-forward',
+        middlewareUrl: 'https://example.com',
+        chat: { pillLauncher },
+      });
+
+      const chatInstance = vi.mocked(GengageChat).mock.instances[0] as Record<string, ReturnType<typeof vi.fn>>;
+      const initArg = chatInstance['init'].mock.calls[0][0] as Record<string, unknown>;
+      expect(initArg['pillLauncher']).toEqual(pillLauncher);
     });
   });
 });

--- a/tests/overlay.test.ts
+++ b/tests/overlay.test.ts
@@ -217,17 +217,18 @@ describe('overlay', () => {
       expect(initArg['headerTitle']).toBe("Koçtaş'a Sor");
     });
 
-    it('falls back to chat.headerTitle for QNA when qna.headerTitle is not set', async () => {
+    it('does NOT inherit chat.headerTitle for QNA when qna.headerTitle is absent', async () => {
       await initOverlayWidgets({
-        accountId: 'qna-headertitle-fallback',
+        accountId: 'qna-headertitle-no-fallback',
         middlewareUrl: 'https://example.com',
         sku: 'SKU123',
         chat: { headerTitle: "Boyner'e Sor" },
+        // qna.headerTitle deliberately absent — must not be silently inherited
       });
 
       const qnaInstance = vi.mocked(GengageQNA).mock.instances[0] as Record<string, ReturnType<typeof vi.fn>>;
       const initArg = qnaInstance['init'].mock.calls[0][0] as Record<string, unknown>;
-      expect(initArg['headerTitle']).toBe("Boyner'e Sor");
+      expect(initArg['headerTitle']).toBeUndefined();
     });
 
     it('qna.headerTitle takes precedence over chat.headerTitle', async () => {

--- a/tests/pill-launcher.test.ts
+++ b/tests/pill-launcher.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { makePillLauncher } from '../src/common/pill-launcher.js';
 
+function makeHost(): { host: HTMLElement; shadow: ShadowRoot; button: HTMLButtonElement } {
+  const host = document.createElement('div');
+  host.dataset['gengageWidget'] = 'gengagechat';
+  const shadow = host.attachShadow({ mode: 'open' });
+  const button = document.createElement('button');
+  button.dataset['gengagePart'] = 'chat-launcher-button';
+  shadow.appendChild(button);
+  document.body.appendChild(host);
+  return { host, shadow, button };
+}
+
 describe('makePillLauncher', () => {
   describe('return value', () => {
     it('launcherImageUrl equals avatarUrl', () => {
@@ -22,20 +33,48 @@ describe('makePillLauncher', () => {
     });
   });
 
-  describe('apply() DOM injection', () => {
-    let host: HTMLElement;
+  describe('apply(shadow) — targeted shadow root', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('targets only the provided shadow root, not the first in DOM order', async () => {
+      const { shadow: shadow1, button: btn1 } = makeHost();
+      const { shadow: shadow2, button: btn2 } = makeHost();
+
+      const kit = makePillLauncher({
+        label: 'Second Widget',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      });
+      await kit.apply(shadow2);
+
+      expect(shadow2.getElementById('gengage-pill-launcher-style')).not.toBeNull();
+      expect(btn2.querySelector('.gengage-pill-launcher-label')?.textContent).toBe('Second Widget');
+      expect(shadow1.getElementById('gengage-pill-launcher-style')).toBeNull();
+      expect(btn1.querySelector('.gengage-pill-launcher-label')).toBeNull();
+    });
+
+    it('injects style and label when shadow is passed explicitly', async () => {
+      const { shadow, button } = makeHost();
+      const kit = makePillLauncher({
+        label: 'Direct Shadow',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#ff0000',
+      });
+      await kit.apply(shadow);
+      expect(shadow.getElementById('gengage-pill-launcher-style')).not.toBeNull();
+      expect(button.querySelector('.gengage-pill-launcher-label')?.textContent).toBe('Direct Shadow');
+    });
+  });
+
+  describe('apply() — global scan fallback', () => {
     let shadow: ShadowRoot;
     let button: HTMLButtonElement;
 
     beforeEach(() => {
       document.body.innerHTML = '';
-      host = document.createElement('div');
-      host.dataset['gengageWidget'] = 'gengagechat';
-      shadow = host.attachShadow({ mode: 'open' });
-      button = document.createElement('button');
-      button.dataset['gengagePart'] = 'chat-launcher-button';
-      shadow.appendChild(button);
-      document.body.appendChild(host);
+      ({ shadow, button } = makeHost());
     });
 
     it('injects a style tag into the shadow root', async () => {
@@ -50,7 +89,7 @@ describe('makePillLauncher', () => {
       expect(style?.tagName.toLowerCase()).toBe('style');
     });
 
-    it('style tag contains the primary color variable', async () => {
+    it('style uses --pill-primary for border (primaryColor is not decorative)', async () => {
       const kit = makePillLauncher({
         label: 'Test',
         avatarUrl: 'https://x.com/img.png',
@@ -59,6 +98,7 @@ describe('makePillLauncher', () => {
       await kit.apply();
       const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement | null;
       expect(style?.textContent).toContain('--pill-primary: #abcdef');
+      expect(style?.textContent).toContain('var(--pill-primary)');
     });
 
     it('style tag contains the secondary color variable', async () => {
@@ -131,27 +171,11 @@ describe('makePillLauncher', () => {
       expect(button.querySelectorAll('.gengage-pill-launcher-label').length).toBe(1);
     });
 
-    it('removes logo class from header avatar if present', async () => {
-      const avatar = document.createElement('img');
-      avatar.dataset['gengagePart'] = 'chat-header-avatar';
-      avatar.classList.add('gengage-chat-header-avatar--logo');
-      shadow.appendChild(avatar);
-
-      const kit = makePillLauncher({
-        label: 'Test',
-        avatarUrl: 'https://x.com/img.png',
-        primaryColor: '#f00',
-      });
-      await kit.apply();
-      expect(avatar.classList.contains('gengage-chat-header-avatar--logo')).toBe(false);
-    });
-
     it('also discovers host via gengage-chat-root class', async () => {
       document.body.innerHTML = '';
       const altHost = document.createElement('div');
       altHost.dataset['gengageWidget'] = 'gengagechat';
       const altShadow = altHost.attachShadow({ mode: 'open' });
-      // No launcher button — only the chat-root class
       const root = document.createElement('div');
       root.className = 'gengage-chat-root';
       altShadow.appendChild(root);
@@ -170,16 +194,75 @@ describe('makePillLauncher', () => {
     });
   });
 
+  describe('header avatar logo class — conditional removal', () => {
+    let shadow: ShadowRoot;
+    let button: HTMLButtonElement;
+
+    beforeEach(() => {
+      document.body.innerHTML = '';
+      ({ shadow, button } = makeHost());
+    });
+
+    it('removes logo class when header and launcher show the same image', async () => {
+      const img = document.createElement('img');
+      img.src = 'https://x.com/same.svg';
+      button.appendChild(img);
+
+      const avatar = document.createElement('img');
+      avatar.src = 'https://x.com/same.svg';
+      avatar.dataset['gengagePart'] = 'chat-header-avatar';
+      avatar.classList.add('gengage-chat-header-avatar--logo');
+      shadow.appendChild(avatar);
+
+      await makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/same.svg',
+        primaryColor: '#f00',
+      }).apply(shadow);
+
+      expect(avatar.classList.contains('gengage-chat-header-avatar--logo')).toBe(false);
+    });
+
+    it('preserves logo class when header avatar differs from launcher image (n11com pattern)', async () => {
+      const img = document.createElement('img');
+      img.src = 'https://x.com/launcher-icon.svg';
+      button.appendChild(img);
+
+      const avatar = document.createElement('img');
+      avatar.src = 'https://x.com/header-logo.png';
+      avatar.dataset['gengagePart'] = 'chat-header-avatar';
+      avatar.classList.add('gengage-chat-header-avatar--logo');
+      shadow.appendChild(avatar);
+
+      await makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/launcher-icon.svg',
+        primaryColor: '#f00',
+      }).apply(shadow);
+
+      expect(avatar.classList.contains('gengage-chat-header-avatar--logo')).toBe(true);
+    });
+
+    it('removes logo class when no launcher img child exists', async () => {
+      const avatar = document.createElement('img');
+      avatar.dataset['gengagePart'] = 'chat-header-avatar';
+      avatar.classList.add('gengage-chat-header-avatar--logo');
+      shadow.appendChild(avatar);
+
+      await makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      }).apply(shadow);
+
+      expect(avatar.classList.contains('gengage-chat-header-avatar--logo')).toBe(false);
+    });
+  });
+
   describe('dimension derivation in CSS', () => {
     it('derives mobile dimensions from custom desktop values', async () => {
       document.body.innerHTML = '';
-      const host = document.createElement('div');
-      host.dataset['gengageWidget'] = 'gengagechat';
-      const shadow = host.attachShadow({ mode: 'open' });
-      const btn = document.createElement('button');
-      btn.dataset['gengagePart'] = 'chat-launcher-button';
-      shadow.appendChild(btn);
-      document.body.appendChild(host);
+      const { shadow } = makeHost();
 
       const kit = makePillLauncher({
         label: 'Test',
@@ -189,7 +272,7 @@ describe('makePillLauncher', () => {
         desktopHeight: '64px',
         iconSize: '50px',
       });
-      await kit.apply();
+      await kit.apply(shadow);
 
       const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement;
       // mobileWidth = 200 - 14 = 186px, mobileHeight = 64 - 4 = 60px, mobileIconSize = 50 - 4 = 46px
@@ -199,20 +282,14 @@ describe('makePillLauncher', () => {
 
     it('uses default desktop dimensions when none specified', async () => {
       document.body.innerHTML = '';
-      const host = document.createElement('div');
-      host.dataset['gengageWidget'] = 'gengagechat';
-      const shadow = host.attachShadow({ mode: 'open' });
-      const btn = document.createElement('button');
-      btn.dataset['gengagePart'] = 'chat-launcher-button';
-      shadow.appendChild(btn);
-      document.body.appendChild(host);
+      const { shadow } = makeHost();
 
       const kit = makePillLauncher({
         label: 'Test',
         avatarUrl: 'https://x.com/img.png',
         primaryColor: '#f00',
       });
-      await kit.apply();
+      await kit.apply(shadow);
 
       const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement;
       // defaults: desktopWidth=188px, desktopHeight=60px, iconSize=46px

--- a/tests/pill-launcher.test.ts
+++ b/tests/pill-launcher.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { makePillLauncher } from '../src/common/pill-launcher.js';
+
+describe('makePillLauncher', () => {
+  describe('return value', () => {
+    it('launcherImageUrl equals avatarUrl', () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://example.com/logo.svg',
+        primaryColor: '#f00',
+      });
+      expect(kit.launcherImageUrl).toBe('https://example.com/logo.svg');
+    });
+
+    it('exposes apply() function', () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://example.com/logo.svg',
+        primaryColor: '#f00',
+      });
+      expect(typeof kit.apply).toBe('function');
+    });
+  });
+
+  describe('apply() DOM injection', () => {
+    let host: HTMLElement;
+    let shadow: ShadowRoot;
+    let button: HTMLButtonElement;
+
+    beforeEach(() => {
+      document.body.innerHTML = '';
+      host = document.createElement('div');
+      host.dataset['gengageWidget'] = 'gengagechat';
+      shadow = host.attachShadow({ mode: 'open' });
+      button = document.createElement('button');
+      button.dataset['gengagePart'] = 'chat-launcher-button';
+      shadow.appendChild(button);
+      document.body.appendChild(host);
+    });
+
+    it('injects a style tag into the shadow root', async () => {
+      const kit = makePillLauncher({
+        label: 'My Label',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#123456',
+      });
+      await kit.apply();
+      const style = shadow.getElementById('gengage-pill-launcher-style');
+      expect(style).not.toBeNull();
+      expect(style?.tagName.toLowerCase()).toBe('style');
+    });
+
+    it('style tag contains the primary color variable', async () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#abcdef',
+      });
+      await kit.apply();
+      const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement | null;
+      expect(style?.textContent).toContain('--pill-primary: #abcdef');
+    });
+
+    it('style tag contains the secondary color variable', async () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+        secondaryColor: '#112233',
+      });
+      await kit.apply();
+      const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement | null;
+      expect(style?.textContent).toContain('--pill-secondary: #112233');
+    });
+
+    it('appends label span to launcher button with correct text', async () => {
+      const kit = makePillLauncher({
+        label: "Koçtaş'a Sor",
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      });
+      await kit.apply();
+      const label = button.querySelector('.gengage-pill-launcher-label');
+      expect(label).not.toBeNull();
+      expect(label?.textContent).toBe("Koçtaş'a Sor");
+    });
+
+    it('sets aria-label on launcher button', async () => {
+      const kit = makePillLauncher({
+        label: 'My Brand',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      });
+      await kit.apply();
+      expect(button.getAttribute('aria-label')).toBe('My Brand');
+    });
+
+    it('uses custom labelClassName', async () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+        labelClassName: 'flormar-launcher-label',
+      });
+      await kit.apply();
+      const label = button.querySelector('.flormar-launcher-label');
+      expect(label).not.toBeNull();
+      expect(label?.textContent).toBe('Test');
+    });
+
+    it('uses custom styleId for the injected style tag', async () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+        styleId: 'flormar-pill-launcher-style',
+      });
+      await kit.apply();
+      expect(shadow.getElementById('flormar-pill-launcher-style')).not.toBeNull();
+      expect(shadow.getElementById('gengage-pill-launcher-style')).toBeNull();
+    });
+
+    it('does not append label span twice on repeated apply()', async () => {
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      });
+      await kit.apply();
+      await kit.apply();
+      expect(button.querySelectorAll('.gengage-pill-launcher-label').length).toBe(1);
+    });
+
+    it('removes logo class from header avatar if present', async () => {
+      const avatar = document.createElement('img');
+      avatar.dataset['gengagePart'] = 'chat-header-avatar';
+      avatar.classList.add('gengage-chat-header-avatar--logo');
+      shadow.appendChild(avatar);
+
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      });
+      await kit.apply();
+      expect(avatar.classList.contains('gengage-chat-header-avatar--logo')).toBe(false);
+    });
+
+    it('also discovers host via gengage-chat-root class', async () => {
+      document.body.innerHTML = '';
+      const altHost = document.createElement('div');
+      altHost.dataset['gengageWidget'] = 'gengagechat';
+      const altShadow = altHost.attachShadow({ mode: 'open' });
+      // No launcher button — only the chat-root class
+      const root = document.createElement('div');
+      root.className = 'gengage-chat-root';
+      altShadow.appendChild(root);
+      const launcherBtn = document.createElement('button');
+      launcherBtn.dataset['gengagePart'] = 'chat-launcher-button';
+      altShadow.appendChild(launcherBtn);
+      document.body.appendChild(altHost);
+
+      const kit = makePillLauncher({
+        label: 'Alt Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#0f0',
+      });
+      await kit.apply();
+      expect(altShadow.getElementById('gengage-pill-launcher-style')).not.toBeNull();
+    });
+  });
+
+  describe('dimension derivation in CSS', () => {
+    it('derives mobile dimensions from custom desktop values', async () => {
+      document.body.innerHTML = '';
+      const host = document.createElement('div');
+      host.dataset['gengageWidget'] = 'gengagechat';
+      const shadow = host.attachShadow({ mode: 'open' });
+      const btn = document.createElement('button');
+      btn.dataset['gengagePart'] = 'chat-launcher-button';
+      shadow.appendChild(btn);
+      document.body.appendChild(host);
+
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+        desktopWidth: '200px',
+        desktopHeight: '64px',
+        iconSize: '50px',
+      });
+      await kit.apply();
+
+      const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement;
+      // mobileWidth = 200 - 14 = 186px, mobileHeight = 64 - 4 = 60px, mobileIconSize = 50 - 4 = 46px
+      expect(style.textContent).toContain('186px');
+      expect(style.textContent).toContain('46px');
+    });
+
+    it('uses default desktop dimensions when none specified', async () => {
+      document.body.innerHTML = '';
+      const host = document.createElement('div');
+      host.dataset['gengageWidget'] = 'gengagechat';
+      const shadow = host.attachShadow({ mode: 'open' });
+      const btn = document.createElement('button');
+      btn.dataset['gengagePart'] = 'chat-launcher-button';
+      shadow.appendChild(btn);
+      document.body.appendChild(host);
+
+      const kit = makePillLauncher({
+        label: 'Test',
+        avatarUrl: 'https://x.com/img.png',
+        primaryColor: '#f00',
+      });
+      await kit.apply();
+
+      const style = shadow.getElementById('gengage-pill-launcher-style') as HTMLStyleElement;
+      // defaults: desktopWidth=188px, desktopHeight=60px, iconSize=46px
+      expect(style.textContent).toContain('188px');
+      expect(style.textContent).toContain('60px');
+      expect(style.textContent).toContain('46px');
+    });
+  });
+});

--- a/tests/qna-renderer.test.ts
+++ b/tests/qna-renderer.test.ts
@@ -84,10 +84,7 @@ describe('renderQnaUISpec', () => {
       },
     };
 
-    const result = renderQnaUISpec(
-      spec,
-      makeContext({ headingTitleOverride: "Teknosa'ya Sor" }),
-    );
+    const result = renderQnaUISpec(spec, makeContext({ headingTitleOverride: "Teknosa'ya Sor" }));
     const heading = result.querySelector('.gengage-qna-heading');
     expect(heading?.textContent).toBe("Teknosa'ya Sor");
   });

--- a/tests/qna-renderer.test.ts
+++ b/tests/qna-renderer.test.ts
@@ -89,6 +89,40 @@ describe('renderQnaUISpec', () => {
     expect(heading?.textContent).toBe("Teknosa'ya Sor");
   });
 
+
+  it('QuestionHeading falls back to stream text when headingTitleOverride is absent', () => {
+    const spec: UISpec = {
+      root: 'root',
+      elements: {
+        root: {
+          type: 'QuestionHeading',
+          props: { text: '👋 Bu ürünü birlikte inceleyelim' },
+        },
+      },
+    };
+
+    const result = renderQnaUISpec(spec, makeContext());
+    const heading = result.querySelector('.gengage-qna-heading');
+    expect(heading?.textContent).toBe('👋 Bu ürünü birlikte inceleyelim');
+  });
+
+  it('QuestionHeading falls back to stream text when headingTitleOverride is empty string', () => {
+    const spec: UISpec = {
+      root: 'root',
+      elements: {
+        root: {
+          type: 'QuestionHeading',
+          props: { text: 'Stream başlığı' },
+        },
+      },
+    };
+
+    const result = renderQnaUISpec(spec, makeContext({ headingTitleOverride: '   ' }));
+    const heading = result.querySelector('.gengage-qna-heading');
+    expect(heading?.textContent).toBe('Stream başlığı');
+  });
+
+
   it('submits TextInput as plain-string user_message payload', () => {
     const onAction = vi.fn();
     const spec: UISpec = {

--- a/tests/qna-renderer.test.ts
+++ b/tests/qna-renderer.test.ts
@@ -73,6 +73,25 @@ describe('renderQnaUISpec', () => {
     expect(send.textContent).toBe('Sor');
   });
 
+  it('QuestionHeading uses headingTitleOverride over stream text', () => {
+    const spec: UISpec = {
+      root: 'root',
+      elements: {
+        root: {
+          type: 'QuestionHeading',
+          props: { text: '👋 Bu ürünü birlikte inceleyelim' },
+        },
+      },
+    };
+
+    const result = renderQnaUISpec(
+      spec,
+      makeContext({ headingTitleOverride: "Teknosa'ya Sor" }),
+    );
+    const heading = result.querySelector('.gengage-qna-heading');
+    expect(heading?.textContent).toBe("Teknosa'ya Sor");
+  });
+
   it('submits TextInput as plain-string user_message payload', () => {
     const onAction = vi.fn();
     const spec: UISpec = {


### PR DESCRIPTION
This pull request updates the chat widget launchers and headers across multiple demo sites to use a new, more customizable "pill launcher" design. It removes legacy launcher image code and replaces it with a configuration object that allows for brand-specific labels, colors, and fonts. Additionally, header titles and avatars are standardized and sourced from remote brand assets, and redundant custom DOM manipulation code is removed where possible.

**Chat Widget Launcher and Header Updates**

* Replaced legacy `launcherImageUrl` usage with a new `pillLauncher` configuration object for all demo sites, enabling brand-specific labels, avatars, primary/secondary colors, and fonts. (`demos/arcelikcomtr/index.html`, `demos/avansascom/index.html`, `demos/aygazcomtr/index.html`, `demos/boynercomtr/index.html`, `demos/defactocomtr/index.html`, `demos/divanpastanelericomtr/index.html`, `demos/evideacom/index.html`, `demos/flocomtr/index.html`, `demos/flormarcomtr/index.html`, `demos/hepsiburadacom/index.html`) [[1]](diffhunk://#diff-36e5116c5c7fee2e8846d89deb7a051c9b4e74a2b82430ae43d59b602f13034fL525-R535) [[2]](diffhunk://#diff-c821ae7a91e0ebdf762f01835f27a77b1094c43d41425f9efbf28e7d3a3f1905L515-R532) [[3]](diffhunk://#diff-91da54b3ce34144ae4eedf6e8568bb83dcdbd30d39ec7394126c7687e23a2c21R515-R530) [[4]](diffhunk://#diff-6bec42eb6871174a9b6e32f9f397858a0d8f54ab7952f4ad8fbafebb87409c10R525-R540) [[5]](diffhunk://#diff-163a7abafd2e57c9175f5adf6ef60a9b86751787e08f54b4ece79d12bc3b1518R524-R539) [[6]](diffhunk://#diff-6b8aa2e95499796f80eaddf43540cd07c99231433ea14cec287468d6915121b9R516-R531) [[7]](diffhunk://#diff-efe03334ecff7a7ed801c1b969cd9ce56aba636b9544bab736f8bc79f4e18bc2R516-R531) [[8]](diffhunk://#diff-9d3dd3b70f0f0a9a244a5c946a0e5d0182027d6688c3d6351532f59974a30983R525-R540) [[9]](diffhunk://#diff-4c1656b2e3610ef9af2716941799e0646c01e79d95ce82eaa079a718cf623c9eL577-R593) [[10]](diffhunk://#diff-d4a8f947db89d702c4174a77c49ef1dba9f0165d35cf7e6467a57451dc9f5e7fR522-R539)

* Updated header avatar URLs to use remote brand assets for consistency and easier updates, and set `headerTitle` for chat and Q&A widgets for all brands. [[1]](diffhunk://#diff-91da54b3ce34144ae4eedf6e8568bb83dcdbd30d39ec7394126c7687e23a2c21R478) [[2]](diffhunk://#diff-6bec42eb6871174a9b6e32f9f397858a0d8f54ab7952f4ad8fbafebb87409c10R488) [[3]](diffhunk://#diff-163a7abafd2e57c9175f5adf6ef60a9b86751787e08f54b4ece79d12bc3b1518R487) [[4]](diffhunk://#diff-6b8aa2e95499796f80eaddf43540cd07c99231433ea14cec287468d6915121b9R479) [[5]](diffhunk://#diff-efe03334ecff7a7ed801c1b969cd9ce56aba636b9544bab736f8bc79f4e18bc2R479) [[6]](diffhunk://#diff-9d3dd3b70f0f0a9a244a5c946a0e5d0182027d6688c3d6351532f59974a30983R488) [[7]](diffhunk://#diff-d4a8f947db89d702c4174a77c49ef1dba9f0165d35cf7e6467a57451dc9f5e7fR487) [[8]](diffhunk://#diff-c821ae7a91e0ebdf762f01835f27a77b1094c43d41425f9efbf28e7d3a3f1905R485-R486) [[9]](diffhunk://#diff-96671586b02bf99ec4ca67acb129f12553fc91e810f02894dc18fa5da5694299L488-R488)

**Code Simplification and Cleanup**

* Removed legacy custom DOM manipulation and CSS injection code for the Flormar launcher, as the new `pillLauncher` configuration now handles all styling and labeling. (`demos/flormarcomtr/index.html`)

**Q&A Widget Improvements**

* Added or standardized `headerTitle` and `ctaText` for Q&A widgets to match the chat widget branding and improve user experience. [[1]](diffhunk://#diff-36e5116c5c7fee2e8846d89deb7a051c9b4e74a2b82430ae43d59b602f13034fL525-R535) [[2]](diffhunk://#diff-c821ae7a91e0ebdf762f01835f27a77b1094c43d41425f9efbf28e7d3a3f1905L515-R532) [[3]](diffhunk://#diff-91da54b3ce34144ae4eedf6e8568bb83dcdbd30d39ec7394126c7687e23a2c21R515-R530) [[4]](diffhunk://#diff-6bec42eb6871174a9b6e32f9f397858a0d8f54ab7952f4ad8fbafebb87409c10R525-R540) [[5]](diffhunk://#diff-163a7abafd2e57c9175f5adf6ef60a9b86751787e08f54b4ece79d12bc3b1518R524-R539) [[6]](diffhunk://#diff-6b8aa2e95499796f80eaddf43540cd07c99231433ea14cec287468d6915121b9R516-R531) [[7]](diffhunk://#diff-efe03334ecff7a7ed801c1b969cd9ce56aba636b9544bab736f8bc79f4e18bc2R516-R531) [[8]](diffhunk://#diff-9d3dd3b70f0f0a9a244a5c946a0e5d0182027d6688c3d6351532f59974a30983R525-R540) [[9]](diffhunk://#diff-4c1656b2e3610ef9af2716941799e0646c01e79d95ce82eaa079a718cf623c9eL577-R593) [[10]](diffhunk://#diff-d4a8f947db89d702c4174a77c49ef1dba9f0165d35cf7e6467a57451dc9f5e7fR522-R539)

These changes ensure a more unified and brand-consistent appearance for all demo chat widgets and simplify the codebase by removing redundant logic.