### PR TITLE
fix: refine watch consulting style picker

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -272,11 +272,7 @@
           color: '#590e2b',
           domain: 'saatvesaat.com.tr',
           nav: ['Kadın Saat', 'Erkek Saat', 'Akıllı Saat', 'Takı', 'Markalar'],
-          skus: [
-            'fossil-erkek-kol-saati-p-ffs6092',
-            'guess-kol-saati-p-guu1461l2m',
-            'milano-x-change-erkek-kol-saati-p-mex3237',
-          ],
+          skus: ['guess-erkek-kol-saati-p-guu1435g3m', 'milano-x-change-erkek-kol-saati-p-mex3237'],
         },
         {
           id: 'trendyolcom',

--- a/demos/saatvesaatcomtr/index.html
+++ b/demos/saatvesaatcomtr/index.html
@@ -501,9 +501,9 @@
           <span class="tab-pill">Değerlendirmeler</span>
         </div>
         <p>
-          Bu demo PDP artık backend'de canlı karşılığı bulunan `GUU1435G3M` Guess erkek klasik saat SKU'sunu
-          varsayılan olarak kullanır. Böylece QNA, benzer ürünler ve watch expert akışları boş dönmeden test
-          edilebilir. Widget verileri bu sayfadaki içerikten bağımsız olarak backend tarafından sağlanır.
+          Bu demo PDP artık backend'de canlı karşılığı bulunan `GUU1435G3M` Guess erkek klasik saat SKU'sunu varsayılan
+          olarak kullanır. Böylece QNA, benzer ürünler ve watch expert akışları boş dönmeden test edilebilir. Widget
+          verileri bu sayfadaki içerikten bağımsız olarak backend tarafından sağlanır.
         </p>
       </section>
 

--- a/demos/saatvesaatcomtr/index.html
+++ b/demos/saatvesaatcomtr/index.html
@@ -448,8 +448,8 @@
         </article>
 
         <article class="summary-card">
-          <div class="badge-chip">%37 İndirim</div>
-          <h1 class="summary-title">GUU1461L2M Erkek Kol Saati — Harley Serisi</h1>
+          <div class="badge-chip">%50 İndirim</div>
+          <h1 class="summary-title">GUU1435G3M Erkek Kol Saati — Guess Classic</h1>
           <div class="summary-meta">
             <span>Marka: Guess</span>
             <span>&bull;</span>
@@ -472,9 +472,9 @@
           </div>
 
           <div class="price-wrap">
-            <div class="price-old">₺7.088,60</div>
-            <div class="price-main">₺4.469,00</div>
-            <div class="price-discount">%37</div>
+            <div class="price-old">₺7.028,30</div>
+            <div class="price-main">₺3.514,15</div>
+            <div class="price-discount">%50</div>
           </div>
 
           <div class="cta-row">
@@ -483,9 +483,9 @@
           </div>
 
           <ul class="feature-list">
-            <li>Su Geçirmezlik: 3 ATM</li>
-            <li>Mekanizma: Quartz</li>
-            <li>Kasa: Çelik, 40mm çap</li>
+            <li>Tarz: Erkek klasik saat</li>
+            <li>Marka: Guess</li>
+            <li>Kasa materyali: Çelik</li>
             <li>Garanti: 2 Yıl</li>
             <li>30 gün içinde iade ve değişim</li>
           </ul>
@@ -501,9 +501,9 @@
           <span class="tab-pill">Değerlendirmeler</span>
         </div>
         <p>
-          Guess Harley Serisi erkek kol saati, şık çelik kasası ve kaliteli quartz mekanizmasıyla dikkat çeken bir
-          tasarıma sahiptir. 40mm kasa çapı ve 3 ATM su geçirmezlik özelliğiyle günlük kullanıma uygundur. Widget
-          verileri bu sayfadaki içerikten bağımsız olarak backend tarafından sağlanır.
+          Bu demo PDP artık backend'de canlı karşılığı bulunan `GUU1435G3M` Guess erkek klasik saat SKU'sunu
+          varsayılan olarak kullanır. Böylece QNA, benzer ürünler ve watch expert akışları boş dönmeden test
+          edilebilir. Widget verileri bu sayfadaki içerikten bağımsız olarak backend tarafından sağlanır.
         </p>
       </section>
 
@@ -521,7 +521,7 @@
       import { initOverlayWidgets } from '@gengage/assistant-fe';
 
       const params = new URLSearchParams(location.search);
-      const sku = params.get('sku') ?? 'GUU1461L2M';
+      const sku = params.get('sku') ?? 'guess-erkek-kol-saati-p-guu1435g3m';
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
 
       const skuDisplay = sku ?? '—';

--- a/src/chat/components/ConsultingStylePicker.ts
+++ b/src/chat/components/ConsultingStylePicker.ts
@@ -22,6 +22,12 @@ export type StyleVariation = {
   recommendation_groups?: Array<{ label?: string; reason?: string; skus?: string[] }>;
 };
 
+type ConsultingProductSection = {
+  labelText: string;
+  products: StyleVariationProduct[];
+  reasonText?: string;
+};
+
 /** Normalise a consulting image URL from the backend (absolute or relative). */
 export function toConsultingImageUrl(input: unknown): string | undefined {
   if (typeof input !== 'string') return undefined;
@@ -92,16 +98,11 @@ export function renderConsultingStylePicker(
         const sku = typeof product?.['sku'] === 'string' ? (product['sku'] as string) : undefined;
         if (sku) productBySku.set(sku, product);
       }
-      const visibleGroupCount = recommendationGroups.filter((group) => {
-        const skus = Array.isArray(group.skus)
-          ? group.skus.filter((sku): sku is string => typeof sku === 'string' && sku.trim().length > 0)
-          : [];
-        return skus.some((sku) => productBySku.has(sku));
-      }).length;
 
       const renderGroupSection = (
         labelText: string,
         groupedProducts: StyleVariationProduct[],
+        isSingleSection: boolean,
         reasonText?: string,
       ): void => {
         if (groupedProducts.length === 0) return;
@@ -127,9 +128,8 @@ export function renderConsultingStylePicker(
         section.appendChild(header);
 
         const groupGrid = document.createElement('div');
-        groupGrid.className =
-          'gengage-chat-product-grid gengage-chat-product-grid--mobile gengage-chat-consulting-group-grid';
-        if (visibleGroupCount <= 1) {
+        groupGrid.className = 'gengage-chat-product-grid gengage-chat-consulting-group-grid';
+        if (isSingleSection) {
           groupGrid.classList.add('gengage-chat-consulting-group-grid--single-group');
         }
         groupGrid.style.setProperty(
@@ -152,6 +152,7 @@ export function renderConsultingStylePicker(
       };
 
       const renderedSkus = new Set<string>();
+      const sections: ConsultingProductSection[] = [];
       for (const group of recommendationGroups) {
         const skus = Array.isArray(group.skus)
           ? group.skus.filter((sku): sku is string => typeof sku === 'string' && sku.trim().length > 0)
@@ -165,7 +166,11 @@ export function renderConsultingStylePicker(
         if (groupedProducts.length === 0) continue;
         const labelText = typeof group.label === 'string' && group.label.trim().length > 0 ? group.label : 'Öneri';
         const reasonText = typeof group.reason === 'string' ? group.reason : undefined;
-        renderGroupSection(labelText, groupedProducts, reasonText);
+        sections.push({
+          labelText,
+          products: groupedProducts,
+          ...(reasonText !== undefined ? { reasonText } : {}),
+        });
       }
 
       const leftovers = products.filter((product) => {
@@ -173,7 +178,15 @@ export function renderConsultingStylePicker(
         return sku.length > 0 && !renderedSkus.has(sku);
       });
       if (leftovers.length > 0) {
-        renderGroupSection('Diğer Uyumlu Ürünler', leftovers);
+        sections.push({
+          labelText: ctx?.i18n?.consultingOtherCompatibleProductsLabel ?? 'Other compatible products',
+          products: leftovers,
+        });
+      }
+
+      const isSingleSection = sections.length === 1;
+      for (const section of sections) {
+        renderGroupSection(section.labelText, section.products, isSingleSection, section.reasonText);
       }
       return;
     }

--- a/src/chat/components/ConsultingStylePicker.ts
+++ b/src/chat/components/ConsultingStylePicker.ts
@@ -80,7 +80,11 @@ export function renderConsultingStylePicker(
     grid.innerHTML = '';
     const products = Array.isArray(variation.product_list) ? variation.product_list : [];
     const recommendationGroups =
-      source === 'watch_expert' ? [] : Array.isArray(variation.recommendation_groups) ? variation.recommendation_groups : [];
+      source === 'watch_expert'
+        ? []
+        : Array.isArray(variation.recommendation_groups)
+          ? variation.recommendation_groups
+          : [];
 
     if (recommendationGroups.length > 0) {
       const productBySku = new Map<string, StyleVariationProduct>();

--- a/src/chat/components/ConsultingStylePicker.ts
+++ b/src/chat/components/ConsultingStylePicker.ts
@@ -79,7 +79,8 @@ export function renderConsultingStylePicker(
   const renderVariationProducts = (variation: StyleVariation): void => {
     grid.innerHTML = '';
     const products = Array.isArray(variation.product_list) ? variation.product_list : [];
-    const recommendationGroups = Array.isArray(variation.recommendation_groups) ? variation.recommendation_groups : [];
+    const recommendationGroups =
+      source === 'watch_expert' ? [] : Array.isArray(variation.recommendation_groups) ? variation.recommendation_groups : [];
 
     if (recommendationGroups.length > 0) {
       const productBySku = new Map<string, StyleVariationProduct>();
@@ -87,19 +88,19 @@ export function renderConsultingStylePicker(
         const sku = typeof product?.['sku'] === 'string' ? (product['sku'] as string) : undefined;
         if (sku) productBySku.set(sku, product);
       }
-
-      const renderedSkus = new Set<string>();
-      for (const group of recommendationGroups) {
+      const visibleGroupCount = recommendationGroups.filter((group) => {
         const skus = Array.isArray(group.skus)
           ? group.skus.filter((sku): sku is string => typeof sku === 'string' && sku.trim().length > 0)
           : [];
-        const groupedProducts = skus
-          .map((sku) => {
-            renderedSkus.add(sku);
-            return productBySku.get(sku);
-          })
-          .filter((product): product is StyleVariationProduct => !!product);
-        if (groupedProducts.length === 0) continue;
+        return skus.some((sku) => productBySku.has(sku));
+      }).length;
+
+      const renderGroupSection = (
+        labelText: string,
+        groupedProducts: StyleVariationProduct[],
+        reasonText?: string,
+      ): void => {
+        if (groupedProducts.length === 0) return;
 
         const section = document.createElement('section');
         section.className = 'gengage-chat-consulting-group';
@@ -109,21 +110,24 @@ export function renderConsultingStylePicker(
 
         const label = document.createElement('h4');
         label.className = 'gengage-chat-consulting-group-label';
-        const labelText = typeof group.label === 'string' && group.label.trim().length > 0 ? group.label : 'Öneri';
-        label.textContent = skus.length > 0 ? `${labelText} (${skus.length})` : labelText;
+        label.textContent = `${labelText} (${groupedProducts.length})`;
         header.appendChild(label);
 
-        if (typeof group.reason === 'string' && group.reason.trim().length > 0) {
+        if (typeof reasonText === 'string' && reasonText.trim().length > 0) {
           const reason = document.createElement('p');
           reason.className = 'gengage-chat-consulting-group-reason';
-          reason.textContent = group.reason;
+          reason.textContent = reasonText;
           header.appendChild(reason);
         }
 
         section.appendChild(header);
 
         const groupGrid = document.createElement('div');
-        groupGrid.className = 'gengage-chat-product-grid gengage-chat-consulting-group-grid';
+        groupGrid.className =
+          'gengage-chat-product-grid gengage-chat-product-grid--mobile gengage-chat-consulting-group-grid';
+        if (visibleGroupCount <= 1) {
+          groupGrid.classList.add('gengage-chat-consulting-group-grid--single-group');
+        }
         groupGrid.style.setProperty(
           '--consulting-group-columns',
           String(Math.max(1, Math.min(4, groupedProducts.length))),
@@ -141,6 +145,23 @@ export function renderConsultingStylePicker(
         }
         section.appendChild(groupGrid);
         grid.appendChild(section);
+      };
+
+      const renderedSkus = new Set<string>();
+      for (const group of recommendationGroups) {
+        const skus = Array.isArray(group.skus)
+          ? group.skus.filter((sku): sku is string => typeof sku === 'string' && sku.trim().length > 0)
+          : [];
+        const groupedProducts = skus
+          .map((sku) => {
+            renderedSkus.add(sku);
+            return productBySku.get(sku);
+          })
+          .filter((product): product is StyleVariationProduct => !!product);
+        if (groupedProducts.length === 0) continue;
+        const labelText = typeof group.label === 'string' && group.label.trim().length > 0 ? group.label : 'Öneri';
+        const reasonText = typeof group.reason === 'string' ? group.reason : undefined;
+        renderGroupSection(labelText, groupedProducts, reasonText);
       }
 
       const leftovers = products.filter((product) => {
@@ -148,24 +169,7 @@ export function renderConsultingStylePicker(
         return sku.length > 0 && !renderedSkus.has(sku);
       });
       if (leftovers.length > 0) {
-        const fallbackGrid = document.createElement('div');
-        fallbackGrid.className = 'gengage-chat-product-grid gengage-chat-consulting-group-grid';
-        fallbackGrid.style.setProperty(
-          '--consulting-group-columns',
-          String(Math.max(1, Math.min(4, leftovers.length))),
-        );
-        for (const product of leftovers) {
-          const cardElement: UIElement = {
-            type: 'ProductCard',
-            props: { product },
-          };
-          const card = renderProductCard(
-            cardElement,
-            ctx ?? ({ onAction: () => undefined } as ChatUISpecRenderContext),
-          );
-          fallbackGrid.appendChild(card);
-        }
-        grid.appendChild(fallbackGrid);
+        renderGroupSection('Diğer Uyumlu Ürünler', leftovers);
       }
       return;
     }
@@ -201,7 +205,6 @@ export function renderConsultingStylePicker(
       addImageErrorHandler(img);
       media.appendChild(img);
     }
-
     const caption = document.createElement('span');
     caption.className = 'gengage-chat-consulting-style-caption';
     caption.textContent = variation.style_label ?? `Style ${index + 1}`;

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -6457,6 +6457,17 @@ button.gengage-chat-product-details-rating {
   grid-template-columns: 1fr;
 }
 
+.gengage-chat-root--mobile .gengage-chat-consulting-group-grid.gengage-chat-consulting-group-grid--single-group {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.gengage-chat-root--mobile .gengage-chat-consulting-group-grid .gengage-chat-product-card {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
+}
+
 .gengage-chat-product-grid-head {
   display: flex;
   align-items: center;

--- a/src/chat/locales/en.ts
+++ b/src/chat/locales/en.ts
@@ -66,6 +66,7 @@ export const CHAT_I18N_EN: ChatI18n = {
   galleryNextAriaLabel: 'Next image',
   beautyStylesPreparedTitle: 'Prepared {count} beauty styles for you',
   watchStylesPreparedTitle: 'Prepared {count} style directions for you',
+  consultingOtherCompatibleProductsLabel: 'Other compatible products',
   choicePrompterHeading: "Can't decide?",
   choicePrompterSuggestion: 'Select products to compare them',
   choicePrompterCta: 'Select & Compare',

--- a/src/chat/locales/tr.ts
+++ b/src/chat/locales/tr.ts
@@ -66,6 +66,7 @@ export const CHAT_I18N_TR: ChatI18n = {
   galleryNextAriaLabel: 'Sonraki görsel',
   beautyStylesPreparedTitle: 'Sizin için {count} farklı stil hazırladım',
   watchStylesPreparedTitle: 'Sizin için {count} farklı stil yönü hazırladım',
+  consultingOtherCompatibleProductsLabel: 'Diğer Uyumlu Ürünler',
   choicePrompterHeading: 'Kararsız mı kaldın?',
   choicePrompterSuggestion: 'Ürünleri seçip karşılaştırabilirsin',
   choicePrompterCta: 'Seç ve Karşılaştır',

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -240,6 +240,8 @@ export interface ChatI18n {
   beautyStylesPreparedTitle: string;
   /** Title shown above watch-expert style cards. Supports {count} placeholder. */
   watchStylesPreparedTitle: string;
+  /** Label for products that were not included in a backend recommendation group. */
+  consultingOtherCompatibleProductsLabel: string;
   choicePrompterHeading: string;
   choicePrompterSuggestion: string;
   choicePrompterCta: string;
@@ -416,6 +418,7 @@ export interface ChatUISpecRenderContext {
     | 'galleryNextAriaLabel'
     | 'beautyStylesPreparedTitle'
     | 'watchStylesPreparedTitle'
+    | 'consultingOtherCompatibleProductsLabel'
     | 'viewMoreLabel'
     | 'similarProductsLabel'
     | 'addToCartButton'

--- a/tests/render-uispec.test.ts
+++ b/tests/render-uispec.test.ts
@@ -400,6 +400,116 @@ describe('renderUISpec', () => {
       expect(grid).toBeTruthy();
       expect(grid.querySelectorAll('.gengage-chat-product-card')).toHaveLength(2);
     });
+
+    it('renders a single consulting recommendation group without the generic mobile grid class', () => {
+      const spec: UISpec = {
+        root: 'root',
+        elements: {
+          root: {
+            type: 'ProductGrid',
+            props: {
+              source: 'beauty_consulting',
+              styleVariations: [
+                {
+                  style_label: 'Daily',
+                  product_list: [
+                    { sku: 'A', name: 'Product A', url: '/a' },
+                    { sku: 'B', name: 'Product B', url: '/b' },
+                  ],
+                  recommendation_groups: [{ label: 'Core Picks', reason: 'Works well together', skus: ['A', 'B'] }],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = renderUISpec(spec, makeContext());
+      const groupGrid = result.querySelector('.gengage-chat-consulting-group-grid')!;
+
+      expect(result.querySelectorAll('.gengage-chat-consulting-group')).toHaveLength(1);
+      expect(groupGrid.classList.contains('gengage-chat-product-grid--mobile')).toBe(false);
+      expect(groupGrid.classList.contains('gengage-chat-consulting-group-grid--single-group')).toBe(true);
+      expect(result.querySelector('.gengage-chat-consulting-group-label')?.textContent).toBe('Core Picks (2)');
+    });
+
+    it('counts leftover consulting products as their own section before applying single-group layout', () => {
+      const spec: UISpec = {
+        root: 'root',
+        elements: {
+          root: {
+            type: 'ProductGrid',
+            props: {
+              source: 'beauty_consulting',
+              styleVariations: [
+                {
+                  style_label: 'Daily',
+                  product_list: [
+                    { sku: 'A', name: 'Product A', url: '/a' },
+                    { sku: 'B', name: 'Product B', url: '/b' },
+                  ],
+                  recommendation_groups: [{ label: 'Core Picks', skus: ['A'] }],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = renderUISpec(
+        spec,
+        makeContext({
+          i18n: {
+            consultingOtherCompatibleProductsLabel: 'More matches',
+          } as UISpecRenderContext['i18n'],
+        }),
+      );
+      const groupGrids = result.querySelectorAll('.gengage-chat-consulting-group-grid');
+      const labels = Array.from(result.querySelectorAll('.gengage-chat-consulting-group-label')).map(
+        (label) => label.textContent,
+      );
+
+      expect(result.querySelectorAll('.gengage-chat-consulting-group')).toHaveLength(2);
+      expect(labels).toEqual(['Core Picks (1)', 'More matches (1)']);
+      expect(Array.from(groupGrids).some((grid) => grid.classList.contains('gengage-chat-product-grid--mobile'))).toBe(
+        false,
+      );
+      expect(
+        Array.from(groupGrids).some((grid) =>
+          grid.classList.contains('gengage-chat-consulting-group-grid--single-group'),
+        ),
+      ).toBe(false);
+    });
+
+    it('ignores recommendation groups for watch expert consulting grids', () => {
+      const spec: UISpec = {
+        root: 'root',
+        elements: {
+          root: {
+            type: 'ProductGrid',
+            props: {
+              source: 'watch_expert',
+              styleVariations: [
+                {
+                  style_label: 'Classic',
+                  product_list: [
+                    { sku: 'A', name: 'Product A', url: '/a' },
+                    { sku: 'B', name: 'Product B', url: '/b' },
+                  ],
+                  recommendation_groups: [{ label: 'Should not render', skus: ['A'] }],
+                },
+              ],
+            },
+          },
+        },
+      };
+
+      const result = renderUISpec(spec, makeContext());
+
+      expect(result.querySelector('.gengage-chat-consulting-group')).toBeNull();
+      expect(result.querySelectorAll('.gengage-chat-product-card')).toHaveLength(2);
+      expect(result.textContent).not.toContain('Should not render');
+    });
   });
 
   describe('Image Gallery', () => {


### PR DESCRIPTION
## Summary

This PR tightens the consulting style picker behavior for watch-expert flows and updates the Saat & Saat demo to use a live SKU that actually exercises the flow.

## What Changed

### 1. Watch expert no longer renders grouped recommendation sections

`renderConsultingStylePicker(...)` now suppresses `recommendation_groups` when the source is `watch_expert` and renders the flat `product_list` instead.

Why:
- the watch flow currently works better as a flat set of product cards per style direction
- grouped headers/reasons were introducing extra structure that did not add much value for watch recommendations
- this keeps beauty grouping behavior intact while simplifying the watch presentation path

### 2. Beauty grouped rendering got cleaner fallback behavior

For grouped flows that still use `recommendation_groups`:
- empty groups are skipped
- grouped section rendering is centralized through a helper
- leftover products are rendered under `Diğer Uyumlu Ürünler` instead of being dropped into a separate anonymous grid

### 3. Mobile grouped-card layout is improved

On mobile, a single visible consulting group now renders as a 2-column grid and product cards are allowed to stretch full width within that grid. This makes grouped beauty recommendations denser and less awkward when only one section is visible.

### 4. Saat & Saat demo now uses a live SKU

The local demo previously defaulted to a SKU that did not reliably exercise the backend flow.

This PR updates `demos/saatvesaatcomtr/index.html` to use a live Guess PDP SKU so:
- QNA
- similar products
- watch expert style-direction testing

can be validated against a working product context.

## Files

- `src/chat/components/ConsultingStylePicker.ts`
- `src/chat/components/chat.css`
- `demos/saatvesaatcomtr/index.html`

## Validation

Passed locally:
- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm run build:demos`

Note:
- Vitest prints jsdom `Not implemented: navigation to another Document` warnings during test execution, but the suite passes cleanly.
