### PR TITLE
fix: localize consulting fallback copy

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -345,6 +345,8 @@ await chatWidget.init({
     // Style variation picker
     beautyStylesPreparedTitle: 'Sizin için {count} farklı stil hazırladım',
     watchStylesPreparedTitle: 'Sizin için {count} farklı stil yönü hazırladım',
+    consultingFallbackGroupLabel: 'Öneri',
+    consultingFallbackStyleLabel: 'Stil {index}',
     consultingStyleLoadingDescription: 'Bu stil için ürünleri toplamaya devam ediyorum.',
     consultingStyleUnavailableDescription: 'Bu stil için şu anda yeterli ürün eşleşmesi çıkaramadım.',
     consultingStyleLoadingBadge: 'Yükleniyor',

--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -76,6 +76,7 @@ await chat.init({
 
 - Chat has the deepest i18n surface because it owns recovery UI, panel titles, voice labels, consulting mode strings, and attachment flows.
 - Beauty and watch consulting strings are also supplied through `ChatI18n` and can be overridden without replacing renderers.
+- Consulting fallback labels such as unnamed recommendation groups, fallback style-card captions, the beauty selfie step, and the photo-analysis card all resolve through `src/chat/locales/` the same way as the rest of the chat widget.
 - `choicePrompter` is intentionally suppressed in beauty-consulting mode regardless of locale.
 
 ## Related Docs

--- a/src/chat/components/BeautyPhotoStep.ts
+++ b/src/chat/components/BeautyPhotoStep.ts
@@ -15,6 +15,7 @@
  */
 
 import type { UIElement } from '../../common/types.js';
+import { CHAT_I18N_TR } from '../locales/index.js';
 import type { ChatUISpecRenderContext } from '../types.js';
 
 export interface BeautyPhotoStepProps {
@@ -48,6 +49,7 @@ export function renderBeautyPhotoStep(
 ): HTMLElement {
   const props = element.props ?? {};
   const processing = props['processing'] === true;
+  const i18n = { ...CHAT_I18N_TR, ...(ctx.i18n ?? {}) };
 
   const card = document.createElement('div');
   card.className = 'gengage-chat-beauty-photo-step-card';
@@ -62,17 +64,11 @@ export function renderBeautyPhotoStep(
 
   const titleEl = document.createElement('div');
   titleEl.className = 'gengage-chat-beauty-photo-step-title';
-  titleEl.textContent =
-    (typeof props['title'] === 'string' ? props['title'] : undefined) ??
-    ctx.i18n?.beautyPhotoStepTitle ??
-    'Upload a Photo';
+  titleEl.textContent = (typeof props['title'] === 'string' ? props['title'] : undefined) ?? i18n.beautyPhotoStepTitle;
 
   const desc = document.createElement('p');
   desc.className = 'gengage-chat-beauty-photo-step-desc';
-  desc.textContent =
-    (typeof props['description'] === 'string' ? props['description'] : undefined) ??
-    ctx.i18n?.beautyPhotoStepDescription ??
-    'Share a selfie so we can analyze your skin and recommend the right products.';
+  desc.textContent = (typeof props['description'] === 'string' ? props['description'] : undefined) ?? i18n.beautyPhotoStepDescription;
 
   const actions = document.createElement('div');
   actions.className = 'gengage-chat-beauty-photo-step-actions';
@@ -81,10 +77,9 @@ export function renderBeautyPhotoStep(
   uploadBtn.type = 'button';
   uploadBtn.className = 'gengage-chat-beauty-photo-step-upload gds-btn gds-btn-primary';
   uploadBtn.textContent = processing
-    ? (ctx.i18n?.beautyPhotoStepProcessing ?? 'Analyzing...')
+    ? i18n.beautyPhotoStepProcessing
     : ((typeof props['upload_label'] === 'string' ? props['upload_label'] : undefined) ??
-      ctx.i18n?.beautyPhotoStepUpload ??
-      'Upload Photo');
+      i18n.beautyPhotoStepUpload);
   uploadBtn.disabled = processing;
   if (callbacks?.onUpload) {
     uploadBtn.addEventListener('click', () => callbacks.onUpload!());
@@ -93,10 +88,7 @@ export function renderBeautyPhotoStep(
   const skipBtn = document.createElement('button');
   skipBtn.type = 'button';
   skipBtn.className = 'gengage-chat-beauty-photo-step-skip gds-btn gds-btn-ghost';
-  skipBtn.textContent =
-    (typeof props['skip_label'] === 'string' ? props['skip_label'] : undefined) ??
-    ctx.i18n?.beautyPhotoStepSkip ??
-    'Skip';
+  skipBtn.textContent = (typeof props['skip_label'] === 'string' ? props['skip_label'] : undefined) ?? i18n.beautyPhotoStepSkip;
   if (callbacks?.onSkip) {
     skipBtn.addEventListener('click', () => callbacks.onSkip!());
   }

--- a/src/chat/components/ConsultingStylePicker.ts
+++ b/src/chat/components/ConsultingStylePicker.ts
@@ -10,6 +10,7 @@ import type { UIElement } from '../../common/types.js';
 import type { ChatUISpecRenderContext } from '../types.js';
 import { isSafeUrl, safeSetAttribute } from '../../common/safe-html.js';
 import { addImageErrorHandler } from '../../common/product-utils.js';
+import { CHAT_I18N_TR } from '../locales/index.js';
 import { renderProductCard } from './renderUISpec.js';
 
 export type StyleVariationProduct = Record<string, unknown>;
@@ -67,10 +68,13 @@ export function renderConsultingStylePicker(
   styleVariations: StyleVariation[],
   ctx?: ChatUISpecRenderContext,
 ): void {
-  const loadingBadge = ctx?.i18n?.consultingStyleLoadingBadge ?? 'Loading';
-  const unavailableBadge = ctx?.i18n?.consultingStyleUnavailableBadge ?? 'Not ready';
+  const i18n = { ...CHAT_I18N_TR, ...(ctx?.i18n ?? {}) };
+  const loadingBadge = i18n.consultingStyleLoadingBadge;
+  const unavailableBadge = i18n.consultingStyleUnavailableBadge;
+  const fallbackStyleLabel = (index: number): string => i18n.consultingFallbackStyleLabel.replace('{index}', String(index));
+  const variationLabel = (variation: StyleVariation, index: number): string => variation.style_label ?? fallbackStyleLabel(index);
 
-  const renderVariationPendingState = (variation: StyleVariation, mode: 'loading' | 'unavailable'): void => {
+  const renderVariationPendingState = (variation: StyleVariation, mode: 'loading' | 'unavailable', index: number): void => {
     grid.innerHTML = '';
     grid.classList.remove('gengage-chat-product-grid--consulting-groups');
 
@@ -79,17 +83,15 @@ export function renderConsultingStylePicker(
 
     const title = document.createElement('h4');
     title.className = 'gengage-chat-consulting-loading-panel-title';
-    title.textContent = variation.style_label ?? (mode === 'loading' ? loadingBadge : unavailableBadge);
+    title.textContent = variationLabel(variation, index);
     stateCard.appendChild(title);
 
     const desc = document.createElement('p');
     desc.className = 'gengage-chat-consulting-loading-panel-copy';
     desc.textContent =
       mode === 'loading'
-        ? (ctx?.i18n?.consultingStyleLoadingDescription ??
-          'I am still collecting products for this style. The panel will refresh shortly.')
-        : (ctx?.i18n?.consultingStyleUnavailableDescription ??
-          'I could not find enough product matches for this style yet. You can review the other styles.');
+        ? i18n.consultingStyleLoadingDescription
+        : i18n.consultingStyleUnavailableDescription;
     stateCard.appendChild(desc);
 
     if (mode === 'loading') {
@@ -112,9 +114,7 @@ export function renderConsultingStylePicker(
   const pickerTitle = document.createElement('div');
   pickerTitle.className = 'gengage-chat-consulting-style-picker-title';
   const stylePreparedTemplate =
-    source === 'watch_expert'
-      ? (ctx?.i18n?.watchStylesPreparedTitle ?? 'Prepared {count} style directions for you')
-      : (ctx?.i18n?.beautyStylesPreparedTitle ?? 'Prepared {count} beauty styles for you');
+    source === 'watch_expert' ? i18n.watchStylesPreparedTitle : i18n.beautyStylesPreparedTitle;
   pickerTitle.textContent = stylePreparedTemplate.replace('{count}', String(styleVariations.length));
   picker.appendChild(pickerTitle);
 
@@ -127,14 +127,16 @@ export function renderConsultingStylePicker(
     grid.classList.remove('gengage-chat-product-grid--consulting-groups');
     const variationStatus = typeof variation.status === 'string' ? variation.status : 'ready';
     if (variationStatus === 'loading') {
-      renderVariationPendingState(variation, 'loading');
+      const index = Math.max(0, styleVariations.indexOf(variation)) + 1;
+      renderVariationPendingState(variation, 'loading', index);
       return;
     }
     if (
       variationStatus !== 'ready' &&
       (!Array.isArray(variation.product_list) || variation.product_list.length === 0)
     ) {
-      renderVariationPendingState(variation, 'unavailable');
+      const index = Math.max(0, styleVariations.indexOf(variation)) + 1;
+      renderVariationPendingState(variation, 'unavailable', index);
       return;
     }
     const products = Array.isArray(variation.product_list) ? variation.product_list : [];
@@ -218,7 +220,8 @@ export function renderConsultingStylePicker(
           })
           .filter((product): product is StyleVariationProduct => !!product);
         if (groupedProducts.length === 0) continue;
-        const labelText = typeof group.label === 'string' && group.label.trim().length > 0 ? group.label : 'Öneri';
+        const labelText =
+          typeof group.label === 'string' && group.label.trim().length > 0 ? group.label : i18n.consultingFallbackGroupLabel;
         const reasonText = typeof group.reason === 'string' ? group.reason : undefined;
         sections.push({
           labelText,
@@ -233,7 +236,7 @@ export function renderConsultingStylePicker(
       });
       if (leftovers.length > 0) {
         sections.push({
-          labelText: ctx?.i18n?.consultingOtherCompatibleProductsLabel ?? 'Other compatible products',
+          labelText: i18n.consultingOtherCompatibleProductsLabel,
           products: leftovers,
         });
       }
@@ -267,7 +270,7 @@ export function renderConsultingStylePicker(
     } else if (variationStatus !== 'ready') {
       btn.classList.add('gengage-chat-consulting-style-btn--muted');
     }
-    btn.setAttribute('aria-label', variation.style_label ?? `Style ${index + 1}`);
+    btn.setAttribute('aria-label', variationLabel(variation, index + 1));
 
     const media = document.createElement('div');
     media.className = 'gengage-chat-consulting-style-media';
@@ -277,14 +280,14 @@ export function renderConsultingStylePicker(
       const img = document.createElement('img');
       img.className = 'gengage-chat-consulting-style-image';
       safeSetAttribute(img, 'src', imageUrl);
-      img.alt = variation.style_label ?? `Style ${index + 1}`;
+      img.alt = variationLabel(variation, index + 1);
       img.loading = 'lazy';
       addImageErrorHandler(img);
       media.appendChild(img);
     }
     const caption = document.createElement('span');
     caption.className = 'gengage-chat-consulting-style-caption';
-    caption.textContent = variation.style_label ?? `Style ${index + 1}`;
+    caption.textContent = variationLabel(variation, index + 1);
     media.appendChild(caption);
 
     if (variationStatus === 'loading' || variationStatus !== 'ready') {

--- a/src/chat/components/PhotoAnalysisCard.ts
+++ b/src/chat/components/PhotoAnalysisCard.ts
@@ -7,6 +7,7 @@
  */
 
 import type { UIElement } from '../../common/types.js';
+import { CHAT_I18N_TR } from '../locales/index.js';
 import type { ChatUISpecRenderContext } from '../types.js';
 
 export interface PhotoAnalysisData {
@@ -146,11 +147,12 @@ function analysisLabels(ctx?: ChatUISpecRenderContext): {
   focus: string;
   celebStyle: string;
 } {
+  const i18n = { ...CHAT_I18N_TR, ...(ctx?.i18n ?? {}) };
   return {
-    badge: ctx?.i18n?.photoAnalysisBadge ?? 'Skin Analysis',
-    strengths: ctx?.i18n?.photoAnalysisStrengthsLabel ?? 'Your strengths',
-    focus: ctx?.i18n?.photoAnalysisFocusLabel ?? 'Focus points',
-    celebStyle: ctx?.i18n?.photoAnalysisCelebStyleLabel ?? 'Celeb style match',
+    badge: i18n.photoAnalysisBadge,
+    strengths: i18n.photoAnalysisStrengthsLabel,
+    focus: i18n.photoAnalysisFocusLabel,
+    celebStyle: i18n.photoAnalysisCelebStyleLabel,
   };
 }
 

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -2855,7 +2855,8 @@ button.gengage-chat-product-card-cta {
 }
 
 .gengage-chat-panel .gengage-chat-product-grid.gengage-chat-product-grid--consulting-groups {
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(200px, 240px));
+  justify-content: start;
 }
 
 /*
@@ -6517,6 +6518,7 @@ button.gengage-chat-product-details-rating {
 }
 
 .gengage-chat-panel .gengage-chat-consulting-group {
+  min-width: 0;
   padding: 14px;
   border-radius: 18px;
 }
@@ -6524,8 +6526,8 @@ button.gengage-chat-product-details-rating {
 .gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card {
   width: 100%;
   min-width: 0;
-  max-width: 340px;
-  margin-inline: auto;
+  max-width: 100%;
+  margin-inline: 0;
 }
 
 .gengage-chat-root--mobile .gengage-chat-consulting-style-grid {

--- a/src/chat/locales/en.ts
+++ b/src/chat/locales/en.ts
@@ -67,6 +67,8 @@ export const CHAT_I18N_EN: ChatI18n = {
   beautyStylesPreparedTitle: 'Prepared {count} beauty styles for you',
   watchStylesPreparedTitle: 'Prepared {count} style directions for you',
   consultingOtherCompatibleProductsLabel: 'Other compatible products',
+  consultingFallbackGroupLabel: 'Recommendation',
+  consultingFallbackStyleLabel: 'Style {index}',
   consultingStyleLoadingDescription: 'I am still collecting products for this style. The panel will refresh shortly.',
   consultingStyleUnavailableDescription:
     'I could not find enough product matches for this style yet. You can review the other styles.',

--- a/src/chat/locales/tr.ts
+++ b/src/chat/locales/tr.ts
@@ -67,6 +67,8 @@ export const CHAT_I18N_TR: ChatI18n = {
   beautyStylesPreparedTitle: 'Sizin için {count} farklı stil hazırladım',
   watchStylesPreparedTitle: 'Sizin için {count} farklı stil yönü hazırladım',
   consultingOtherCompatibleProductsLabel: 'Diğer Uyumlu Ürünler',
+  consultingFallbackGroupLabel: 'Öneri',
+  consultingFallbackStyleLabel: 'Stil {index}',
   consultingStyleLoadingDescription:
     'Bu stil için ürünleri toplamaya devam ediyorum. Panel kısa süre içinde yenilenir.',
   consultingStyleUnavailableDescription:

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -242,6 +242,10 @@ export interface ChatI18n {
   watchStylesPreparedTitle: string;
   /** Label for products that were not included in a backend recommendation group. */
   consultingOtherCompatibleProductsLabel: string;
+  /** Fallback label for an unnamed consulting recommendation group. */
+  consultingFallbackGroupLabel: string;
+  /** Fallback label for a consulting style card. Supports {index} placeholder. */
+  consultingFallbackStyleLabel: string;
   consultingStyleLoadingDescription: string;
   consultingStyleUnavailableDescription: string;
   consultingStyleLoadingBadge: string;
@@ -421,6 +425,8 @@ export interface ChatUISpecRenderContext {
     | 'beautyStylesPreparedTitle'
     | 'watchStylesPreparedTitle'
     | 'consultingOtherCompatibleProductsLabel'
+    | 'consultingFallbackGroupLabel'
+    | 'consultingFallbackStyleLabel'
     | 'consultingStyleLoadingDescription'
     | 'consultingStyleUnavailableDescription'
     | 'consultingStyleLoadingBadge'

--- a/tests/consulting-locales.test.ts
+++ b/tests/consulting-locales.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderBeautyPhotoStep } from '../src/chat/components/BeautyPhotoStep.js';
+import { renderConsultingStylePicker } from '../src/chat/components/ConsultingStylePicker.js';
+import { renderPhotoAnalysisCard } from '../src/chat/components/PhotoAnalysisCard.js';
+import { CHAT_I18N_EN } from '../src/chat/locales/en.js';
+import type { ChatUISpecRenderContext } from '../src/chat/types.js';
+import type { UIElement } from '../src/common/types.js';
+
+const renderContext: ChatUISpecRenderContext = {
+  i18n: CHAT_I18N_EN,
+  onAction: () => undefined,
+};
+
+describe('consulting locale renderers', () => {
+  it('renders BeautyPhotoStep with locale-managed defaults', () => {
+    const element: UIElement = {
+      type: 'BeautyPhotoStep',
+      props: { processing: false },
+    };
+
+    const card = renderBeautyPhotoStep(element, renderContext);
+
+    expect(card.textContent).toContain(CHAT_I18N_EN.beautyPhotoStepTitle);
+    expect(card.textContent).toContain(CHAT_I18N_EN.beautyPhotoStepDescription);
+    expect(card.textContent).toContain(CHAT_I18N_EN.beautyPhotoStepUpload);
+    expect(card.textContent).toContain(CHAT_I18N_EN.beautyPhotoStepSkip);
+  });
+
+  it('renders PhotoAnalysisCard labels from ChatI18n', () => {
+    const element: UIElement = {
+      type: 'PhotoAnalysisCard',
+      props: {
+        summary: 'Balanced skin profile',
+        strengths: ['Healthy glow'],
+        focus_points: ['Texture'],
+        celeb_style: 'Soft glam',
+      },
+    };
+
+    const card = renderPhotoAnalysisCard(element, renderContext);
+
+    expect(card.textContent).toContain(CHAT_I18N_EN.photoAnalysisBadge);
+    expect(card.textContent).toContain(CHAT_I18N_EN.photoAnalysisStrengthsLabel);
+    expect(card.textContent).toContain(CHAT_I18N_EN.photoAnalysisFocusLabel);
+    expect(card.textContent).toContain(CHAT_I18N_EN.photoAnalysisCelebStyleLabel);
+  });
+
+  it('renders consulting fallback labels from ChatI18n', () => {
+    const wrapper = document.createElement('div');
+    const grid = document.createElement('div');
+    const product = {
+      sku: 'SKU-1',
+      name: 'Glow Primer',
+      brand: 'Flormar',
+      url: 'https://example.com/product',
+      images: ['https://example.com/product.jpg'],
+      price: 999,
+    };
+
+    renderConsultingStylePicker(
+      wrapper,
+      grid,
+      'beauty_consulting',
+      [
+        {
+          status: 'ready',
+          product_list: [product],
+          recommendation_groups: [{ skus: ['SKU-1'] }],
+        },
+      ],
+      renderContext,
+    );
+
+    expect(wrapper.textContent).toContain(CHAT_I18N_EN.beautyStylesPreparedTitle.replace('{count}', '1'));
+    expect(wrapper.textContent).toContain(CHAT_I18N_EN.consultingFallbackStyleLabel.replace('{index}', '1'));
+    expect(grid.textContent).toContain(`${CHAT_I18N_EN.consultingFallbackGroupLabel} (1)`);
+  });
+});


### PR DESCRIPTION
## Summary
This PR moves consulting-mode fallback copy onto the chat locale system so beauty/watch renderer text behaves like the rest of `gengage-assistant-fe`: locale-resolved first, overrideable through partial `i18n`, and safe under partial render-context overrides.

## Developer / Product Analysis
The underlying product issue was not only "some texts were English". The deeper problem was that several consulting renderers still owned their own inline fallback strings, which made them behave differently from the rest of the chat widget.

That created three problems:
- locale drift: consulting fallback labels could leak English/Turkish inconsistently
- customization drift: host integrations could not reliably override those strings through the standard `i18n` surface
- renderer fragility: partial `ctx.i18n` overrides could leave required consulting labels undefined

This PR brings those surfaces back under the same locale model as the rest of the project.

### What changed
1. Expanded `ChatI18n` for consulting fallback labels
- added `consultingFallbackGroupLabel`
- added `consultingFallbackStyleLabel`
- wired them through the chat locale objects in `tr.ts` and `en.ts`

2. Removed inline consulting fallback strings from renderers
- `BeautyPhotoStep`
- `PhotoAnalysisCard`
- `ConsultingStylePicker`

3. Matched the project’s locale-resolution pattern in renderer code
- renderers now merge `CHAT_I18N_TR` defaults with any partial `ctx.i18n`
- this keeps partial override behavior safe and consistent with the rest of the widget system

4. Preserved consulting layout work already on the branch
- the consulting grid CSS adjustments remain included and were validated in the production build and test suite

5. Updated docs
- `docs/i18n.md`
- `docs/customization.md`

## Why this shape is minimal
- no new localization framework was introduced
- no widget-level API changed beyond extending the existing `ChatI18n` surface
- the implementation reuses the current typed locale-object pattern already used across chat/qna/simrel

## Tests and Verification
### Frontend quality gates
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`

### Added regression coverage
- localized defaults for `BeautyPhotoStep`
- localized labels for `PhotoAnalysisCard`
- consulting fallback group/style labels through `ConsultingStylePicker`

## Risk Notes
- the main behavior change is stronger reliance on locale objects for consulting fallback copy
- renderers now safely tolerate partial `ctx.i18n` objects, which reduces regression risk for existing integrations and internal tests

## Review Notes
- branch review was completed locally; no additional in-branch code review is needed
