### PR TITLE
Fix stale panel restore after empty text responses

### DIFF
--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -1691,9 +1691,10 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     // Exception: getComparisonTable shows the panel skeleton immediately (desktop + mobile)
     // so users see progress while the table streams in.
     // Captures the panel source (UISpec/kind) so it can be re-rendered with fresh
-    // event listeners if the backend fails to deliver new panel content.
+    // event listeners if a non-text action fails to deliver new panel content.
     let prePanelSource = this._currentPanelSource;
     let prePanelSourceCaptured = false;
+    const shouldClearStalePanelOnEmptyResponse = action.type === 'user_message' || action.type === 'inputText';
     const capturePanelSourceIfNeeded = (): void => {
       if (prePanelSourceCaptured || options?.preservePanel) return;
       prePanelSource = this._currentPanelSource;
@@ -1701,7 +1702,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     };
     const restoreOrClearPanel = (): void => {
       if (!this._drawer?.isPanelLoading()) return;
-      if (prePanelSource) {
+      if (!shouldClearStalePanelOnEmptyResponse && prePanelSource) {
         const ctx = this._buildRenderContext();
         const el = this._renderPanelFromSource(prePanelSource, ctx);
         this._drawer.setPanelContent(el);

--- a/tests/chat-panel-loading-regression.test.ts
+++ b/tests/chat-panel-loading-regression.test.ts
@@ -24,6 +24,7 @@ async function createChat(): Promise<GengageChat> {
   const chat = new GengageChat();
   await chat.init({
     accountId: 'test-account',
+    middlewareUrl: 'https://test.example.com',
     session: { sessionId: 'test-session' },
   });
   return chat;

--- a/tests/chat-panel-loading-regression.test.ts
+++ b/tests/chat-panel-loading-regression.test.ts
@@ -126,4 +126,75 @@ describe('Chat panel loading regression', () => {
     expect(title?.textContent).toContain('Ornek Urun');
     chat.destroy();
   });
+
+  it('clears stale panel content when a text request ends after panel loading without new panel ui', async () => {
+    mockedSendChatMessage.mockImplementation((_request, callbacks) => {
+      const callIndex = mockedSendChatMessage.mock.calls.length;
+
+      if (callIndex === 1) {
+        callbacks.onUISpec(
+          {
+            root: 'root',
+            elements: {
+              root: {
+                type: 'ProductCard',
+                props: {
+                  product: {
+                    sku: 'SKU-1',
+                    name: 'Ornek Urun',
+                    price: '1.000 TL',
+                    url: 'https://example.com/p/SKU-1',
+                  },
+                },
+              },
+            },
+          },
+          'chat',
+          'panel',
+        );
+        callbacks.onDone();
+        return new AbortController();
+      }
+
+      callbacks.onMetadata({
+        type: 'metadata',
+        sessionId: '',
+        model: '',
+        meta: { panelLoading: true, panelPendingType: 'productList' },
+      } as never);
+
+      setTimeout(() => callbacks.onDone(), 0);
+      return new AbortController();
+    });
+
+    const chat = await createChat();
+    chat.openWithAction({
+      title: 'Detay',
+      type: 'user_message',
+      payload: 'Ilk urunu goster',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    let shadow = getChatShadow();
+    expect(shadow.querySelector('.gengage-chat-panel--visible')).toBeTruthy();
+    expect(shadow.querySelector('.gengage-chat-product-details-title')?.textContent).toContain('Ornek Urun');
+
+    chat.openWithAction({
+      title: 'Ara',
+      type: 'user_message',
+      payload: 'matkap bul',
+    });
+
+    shadow = getChatShadow();
+    expect(shadow.querySelector('.gengage-chat-panel-skeleton')).toBeTruthy();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    shadow = getChatShadow();
+    expect(shadow.querySelector('.gengage-chat-panel-skeleton')).toBeNull();
+    expect(shadow.querySelector('.gengage-chat-drawer--with-panel')).toBeNull();
+    expect(shadow.querySelector('.gengage-chat-product-details-title')).toBeNull();
+    chat.destroy();
+  });
 });


### PR DESCRIPTION
Fixes #24

## Summary
- clear the side panel instead of restoring the previous panel snapshot when a free-text chat request finishes after `panelLoading` without any new panel UI
- keep the existing restore behavior for non-text actions that legitimately preserve prior panel context
- add a regression test that reproduces a PDP panel followed by a second text request that emits `panelLoading` and then ends without panel content

## Validation
- `npm run test -- tests/chat-panel-loading-regression.test.ts`
- `npm run typecheck`
- browser recheck with an injected `panelLoading` -> stream failure path in the local Arcelik demo