### PR TITLE
fix: skip zero-price values in product normalizer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.31",
+      "version": "0.3.32",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1914,8 +1914,8 @@ export function productToNormalized(p: V1Product): NormalizedProduct {
   const image = p.images?.[0];
   if (image) result.imageUrl = image;
   if (p.images && p.images.length > 1) result.images = p.images;
-  if (price != null) result.price = String(price);
-  if (originalPrice != null) result.originalPrice = String(originalPrice);
+  if (price != null && price > 0) result.price = String(price);
+  if (originalPrice != null && originalPrice > 0) result.originalPrice = String(originalPrice);
   if (discountPercent !== undefined) result.discountPercent = discountPercent;
   if (brand !== undefined) result.brand = brand;
   if (p.rating !== undefined) result.rating = p.rating;


### PR DESCRIPTION
## Summary
- Out-of-stock products from GSS return `price=0` and `price_discounted=0`
- `String(0)` evaluates to `"0"` which is truthy in JS, causing product cards to render "0 TL"
- Now only set `price`/`originalPrice` on the normalized product when the numeric value is positive (`> 0`)
- Bump version to 0.3.32
- Companion backend fix: Glov-ai/micro-abilities#947

## Test plan
- [x] `npm run format` (prettier + eslint + typecheck) — all pass
- [x] `npm test` — 1338/1338 tests pass
- [x] `npm run test:e2e` — 163/163 tests pass
- [ ] Manual verify: out-of-stock product cards no longer show "0 TL"