### PR TITLE
Improve Beymen demo defaults and photo analysis presentation

### DIFF
--- a/demos/beymencom/index.html
+++ b/demos/beymencom/index.html
@@ -484,7 +484,8 @@
       import { initOverlayWidgets } from '@gengage/assistant-fe';
 
       const params = new URLSearchParams(location.search);
-      const sku = params.get('sku') ?? undefined;
+      const defaultSku = '1543302';
+      const sku = params.get('sku') ?? defaultSku;
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
       const beymenHeaderAvatarUrl = 'https://configs.gengage.ai/beymencom/glov-beymencom-logo.png';
 

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -131,6 +131,7 @@ npm run dev -- koctascomtr --sku=1000465056
 | `n11com` | Marketplace, tests product grid with mixed categories |
 | `hepsiburadacom` | High-traffic marketplace, tests performance |
 | `yatasbeddingcomtr` | Furniture, tests large product images and variants |
+| `beymencom` | Luxury beauty/fashion demo; falls back to demo SKU `1543302` when no `sku` query param is supplied |
 | `sephoracomtr` | Beauty retail, uses PDP product code `769798` for the BADgal BANG! maskara set demo |
 
 Use real SKUs from each account's catalog. The dev server startup log prints demo,

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -956,6 +956,19 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     }
   }
 
+  private _focusPresentationThread(
+    threadId: string,
+    behavior: ScrollBehavior = 'smooth',
+    syncDrawerFocus = false,
+  ): void {
+    this._presentation.requestThreadFocus(threadId, behavior);
+    if (syncDrawerFocus) {
+      this._drawer?.setPresentationFocus(threadId);
+    }
+    this._drawer?.setFormerMessagesButtonVisible(false);
+    setTimeout(() => this._flushPresentationScroll(), 40);
+  }
+
   private _releasePresentationFocus(): void {
     this._presentation.releaseFocusedThread();
     this._drawer?.setPresentationFocus(null);
@@ -1739,13 +1752,8 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     this._messages.push(botMsg);
 
     this._presentation.registerAssistantActivity(threadId);
-    this._presentation.requestThreadFocus(threadId, 'smooth');
     // User-visible non-preservePanel: focus was already set before the user bubble.
-    if (options?.silent || isPreservePanel) {
-      this._drawer?.setPresentationFocus(threadId);
-    }
-    this._drawer?.setFormerMessagesButtonVisible(false);
-    setTimeout(() => this._flushPresentationScroll(), 40);
+    this._focusPresentationThread(threadId, 'smooth', options?.silent || isPreservePanel);
 
     // Abort previous request(s) — skip for preservePanel to avoid killing concurrent streams
     if (!options?.preservePanel) {
@@ -1955,6 +1963,9 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             // Photo analysis messages render a structured card — skip typewriter.
             if (isPhotoAnalysisMessage(botMsg)) {
               this._drawer?.updateBotMessage(botMsg.id, displayText, 'photo_analysis', botMsg.photoAnalysis);
+              if (botMsg.threadId) {
+                this._focusPresentationThread(botMsg.threadId, 'auto');
+              }
             } else {
               // Apply typewriter animation to the final bot text
               const bubbleTextEl = this._shadow?.querySelector(
@@ -2023,6 +2034,9 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
               botMsg,
             )
           ) {
+            if (componentType === 'PhotoAnalysisCard' && botMsg.threadId) {
+              this._focusPresentationThread(botMsg.threadId, 'auto');
+            }
             return;
           }
 

--- a/tests/beauty-consulting-migration.test.ts
+++ b/tests/beauty-consulting-migration.test.ts
@@ -433,4 +433,45 @@ describe('beauty consulting migration', () => {
       expect(request.type).toBe('inputText');
     }
   });
+
+  it('reuses presentation-thread focus flow for photo-analysis rendering', () => {
+    vi.useFakeTimers();
+    try {
+      const chat = new GengageChat();
+      const requestThreadFocus = vi.fn();
+      const setPresentationFocus = vi.fn();
+      const setFormerMessagesButtonVisible = vi.fn();
+      const flushPresentationScroll = vi.fn();
+
+      const accessor = chat as unknown as {
+        _presentation: { requestThreadFocus(threadId: string, behavior: ScrollBehavior): void };
+        _drawer?: {
+          setPresentationFocus(threadId: string | null): void;
+          setFormerMessagesButtonVisible(visible: boolean): void;
+        };
+        _flushPresentationScroll(): void;
+        _focusPresentationThread(threadId: string, behavior?: ScrollBehavior, syncDrawerFocus?: boolean): void;
+      };
+
+      accessor._presentation = { requestThreadFocus };
+      accessor._drawer = {
+        setPresentationFocus,
+        setFormerMessagesButtonVisible,
+      };
+      accessor._flushPresentationScroll = flushPresentationScroll;
+
+      accessor._focusPresentationThread('thread-photo', 'auto', true);
+
+      expect(requestThreadFocus).toHaveBeenCalledWith('thread-photo', 'auto');
+      expect(setPresentationFocus).toHaveBeenCalledWith('thread-photo');
+      expect(setFormerMessagesButtonVisible).toHaveBeenCalledWith(false);
+      expect(flushPresentationScroll).not.toHaveBeenCalled();
+
+      vi.runAllTimers();
+
+      expect(flushPresentationScroll).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

This PR now covers two small but important FE quality fixes:

1. make the `beymencom` demo safer to open during local/live testing by giving it a stable default SKU when no `sku` query parameter is supplied
2. keep beauty photo-analysis results inside the existing chat presentation-focus flow so the transcript does not get pushed downward when the analysis card expands

There is no `dev` branch in `gengage-assistant-fe`, so this PR targets `main`.

## What Changed

- Added a `defaultSku` fallback (`1543302`) in `demos/beymencom/index.html`
- Documented that fallback in `docs/live-testing.md`
- Added a small `_focusPresentationThread(...)` helper in `src/chat/index.ts`
- Reused that helper for normal stream-start focus instead of duplicating the same presentation code
- Applied the same focus flow when `PhotoAnalysisCard` renders, both from the beauty UISpec path and from final `photo_analysis` message rendering
- Added a regression test in `tests/beauty-consulting-migration.test.ts`

## Why

### Beymen demo default SKU

Opening the Beymen demo without an explicit `sku` could leave the PDP testing surface in a weak or empty state. For reviewers and QA this creates avoidable friction, especially when the demo is opened directly from the demos index or shared as a raw account URL.

### Photo-analysis presentation behavior

The main shopping experience already uses thread presentation focus plus the existing `↑ Önceki mesajları göster` / `↑ Show earlier messages` flow to keep the newest assistant thread visible without dumping the user into expanded transcript history.

Photo-analysis cards were bypassing that path. They updated the assistant bubble and soft-scrolled downward, which meant the card could expand and push the visible area below the content the user actually wanted to keep in view.

This fix stays intentionally minimal:
- no regex-style text replacement or post-render text mutation
- no new scroll subsystem
- no beauty-specific UI fork
- just reuse of the existing presentation-focus mechanism already used elsewhere in chat

## Validation

- `npm run test -- tests/beauty-consulting-migration.test.ts tests/photo-analysis-typewriter-race.test.ts tests/chat-smart-scroll.test.ts`
- `npm run lint`
- `npm run build`

Result:
- targeted regression tests passed (`22` tests)
- lint passed
- production build passed
