### PR TITLE
grid fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.32",
+      "version": "0.3.33",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/src/chat/components/ConsultingStylePicker.ts
+++ b/src/chat/components/ConsultingStylePicker.ts
@@ -83,6 +83,7 @@ export function renderConsultingStylePicker(
   ): void => {
     grid.innerHTML = '';
     grid.classList.remove('gengage-chat-product-grid--consulting-groups');
+    grid.style.removeProperty('--consulting-sections-columns');
 
     const stateCard = document.createElement('section');
     stateCard.className = 'gengage-chat-consulting-loading-panel';
@@ -129,6 +130,7 @@ export function renderConsultingStylePicker(
   const renderVariationProducts = (variation: StyleVariation): void => {
     grid.innerHTML = '';
     grid.classList.remove('gengage-chat-product-grid--consulting-groups');
+    grid.style.removeProperty('--consulting-sections-columns');
     const variationStatus = typeof variation.status === 'string' ? variation.status : 'ready';
     if (variationStatus === 'loading') {
       const index = Math.max(0, styleVariations.indexOf(variation)) + 1;
@@ -248,6 +250,7 @@ export function renderConsultingStylePicker(
       }
 
       const isSingleSection = sections.length === 1;
+      grid.style.setProperty('--consulting-sections-columns', String(Math.max(1, sections.length)));
       for (const section of sections) {
         renderGroupSection(section.labelText, section.products, isSingleSection, section.reasonText);
       }

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -2854,9 +2854,18 @@ button.gengage-chat-product-card-cta {
   padding: 4px 0;
 }
 
+/* Recommendation group columns: equal width, full row (see --consulting-sections-columns in TS) */
 .gengage-chat-panel .gengage-chat-product-grid.gengage-chat-product-grid--consulting-groups {
-  grid-template-columns: repeat(auto-fit, minmax(200px, 240px));
-  justify-content: start;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  grid-template-columns: repeat(var(--consulting-sections-columns, 3), minmax(0, 1fr));
+  justify-content: stretch;
+  justify-items: stretch;
+}
+
+.gengage-chat-root--mobile .gengage-chat-panel .gengage-chat-product-grid.gengage-chat-product-grid--consulting-groups {
+  grid-template-columns: 1fr;
 }
 
 /*
@@ -6386,6 +6395,9 @@ button.gengage-chat-product-details-rating {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
   padding: 12px;
   border-radius: 16px;
   border: 1px solid color-mix(in srgb, var(--client-primary) 14%, var(--border-default));
@@ -6428,17 +6440,28 @@ button.gengage-chat-product-details-rating {
 .gengage-chat-consulting-group-grid {
   margin-bottom: 2px;
   display: grid;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
   grid-template-columns: repeat(var(--consulting-group-columns, 4), minmax(0, 1fr));
   gap: 14px;
   align-items: stretch;
   justify-content: stretch;
 }
 
+/* Override stream default fixed 160px card; keep cards inside group grid cells. */
 .gengage-chat-consulting-group-grid .gengage-chat-product-card {
   height: 100%;
   width: 100%;
   min-width: 0;
-  max-width: none;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-img-wrapper {
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .gengage-chat-beauty-photo-step {
@@ -6537,6 +6560,26 @@ button.gengage-chat-product-details-rating {
   margin-inline: 0;
 }
 
+/* Panel: image block + text must not push past the grid cell (flex min-size fix). */
+.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-img-wrapper {
+  min-width: 0;
+  max-width: 100%;
+  flex-shrink: 1;
+  align-self: stretch;
+}
+
+.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-body {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-name,
+.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-price,
+.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-price-block {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .gengage-chat-root--mobile .gengage-chat-consulting-style-grid {
   grid-template-columns: 1fr;
 }
@@ -6557,7 +6600,7 @@ button.gengage-chat-product-details-rating {
 .gengage-chat-root--mobile .gengage-chat-consulting-group-grid .gengage-chat-product-card {
   width: 100%;
   min-width: 0;
-  max-width: none;
+  max-width: 100%;
 }
 
 .gengage-chat-root--mobile .gengage-chat-consulting-loading-grid {

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -6561,7 +6561,10 @@ button.gengage-chat-product-details-rating {
 }
 
 /* Panel: image block + text must not push past the grid cell (flex min-size fix). */
-.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-img-wrapper {
+.gengage-chat-panel
+  .gengage-chat-consulting-group-grid
+  .gengage-chat-product-card
+  .gengage-chat-product-card-img-wrapper {
   min-width: 0;
   max-width: 100%;
   flex-shrink: 1;
@@ -6575,7 +6578,10 @@ button.gengage-chat-product-details-rating {
 
 .gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-name,
 .gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-price,
-.gengage-chat-panel .gengage-chat-consulting-group-grid .gengage-chat-product-card .gengage-chat-product-card-price-block {
+.gengage-chat-panel
+  .gengage-chat-consulting-group-grid
+  .gengage-chat-product-card
+  .gengage-chat-product-card-price-block {
   overflow-wrap: anywhere;
   word-break: break-word;
 }


### PR DESCRIPTION
This pull request improves the layout and responsiveness of the consulting product recommendation grids in the chat UI. The main changes ensure that product cards and their contents do not overflow their grid cells, especially when there are multiple recommendation groups or on mobile devices. The CSS and TypeScript updates work together to dynamically set the number of columns and enforce consistent sizing and wrapping for all product card elements.

**Grid column handling and layout improvements:**

* The number of columns in the consulting product grid is now set dynamically using a CSS variable (`--consulting-sections-columns`), which is updated in the TypeScript code based on the number of sections. This ensures the grid adapts to the number of recommendation groups shown. [[1]](diffhunk://#diff-77cbcaa047212cbbb213274d1745404fdc73ecec69ad4bdc124d6cf0de7cbb53R86) [[2]](diffhunk://#diff-77cbcaa047212cbbb213274d1745404fdc73ecec69ad4bdc124d6cf0de7cbb53R133) [[3]](diffhunk://#diff-77cbcaa047212cbbb213274d1745404fdc73ecec69ad4bdc124d6cf0de7cbb53R253) [[4]](diffhunk://#diff-1eb6bebf3ce4a8a2e8527321dbe12996d2904b5d0be970c34beaaa33924d6b9bR2857-R2868)
* On mobile, the grid always displays a single column for better readability and usability.

**Product card sizing and overflow fixes:**

* Product cards and their image wrappers now use `min-width: 0`, `max-width: 100%`, and `box-sizing: border-box` to prevent overflow and ensure they fit within their grid cells. This applies in both desktop and mobile layouts. [[1]](diffhunk://#diff-1eb6bebf3ce4a8a2e8527321dbe12996d2904b5d0be970c34beaaa33924d6b9bR6398-R6400) [[2]](diffhunk://#diff-1eb6bebf3ce4a8a2e8527321dbe12996d2904b5d0be970c34beaaa33924d6b9bR6443-R6464) [[3]](diffhunk://#diff-1eb6bebf3ce4a8a2e8527321dbe12996d2904b5d0be970c34beaaa33924d6b9bL6560-R6603)
* The product card body and image blocks are constrained to their grid cells, and flexbox properties are adjusted to prevent unwanted stretching or overflow.

**Text wrapping and content containment:**

* Product name, price, and price block elements now use `overflow-wrap: anywhere` and `word-break: break-word` to prevent long text from overflowing card boundaries.