### PR TITLE
Comp table and comp mode fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.35",
+      "version": "0.3.36",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test';
 
+// Playwright forces color in worker/web-server processes; keeping NO_COLOR set
+// makes Node print a warning before every spawned process.
+delete process.env.NO_COLOR;
+
 export default defineConfig({
   globalSetup: './tests/e2e/global-setup.ts',
   testDir: './tests/e2e',

--- a/src/chat/components/ComparisonTable.ts
+++ b/src/chat/components/ComparisonTable.ts
@@ -8,6 +8,7 @@
 
 import { sanitizeHtml, isSafeImageUrl } from '../../common/safe-html.js';
 import { formatPrice } from '../../common/price-formatter.js';
+import { resolveLocaleTag } from '../../common/locale.js';
 import type { PriceFormatConfig } from '../../common/price-formatter.js';
 
 /**
@@ -53,12 +54,20 @@ const CRITERIA_DISPLAY_NAMES: Record<string, string> = {
  * Checks locale-specific `criteriaLabels` first (from i18n), then the
  * built-in fallback map, then applies a formatting heuristic.
  */
-export function formatCriteriaName(rawName: string, criteriaLabels?: Record<string, string>): string {
+export function formatCriteriaName(rawName: string, criteriaLabels?: Record<string, string>, locale?: string): string {
   return (
     criteriaLabels?.[rawName] ??
     CRITERIA_DISPLAY_NAMES[rawName] ??
-    rawName.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase())
+    rawName.replace(/_/g, ' ').replace(/^./u, (c) => toLocaleUpperCaseSafe(c, locale))
   );
+}
+
+function toLocaleUpperCaseSafe(value: string, locale: string | undefined): string {
+  try {
+    return value.toLocaleUpperCase(resolveLocaleTag(locale));
+  } catch {
+    return value.toLocaleUpperCase('tr');
+  }
 }
 
 export interface ComparisonProduct {
@@ -99,6 +108,7 @@ export interface ComparisonTableOptions {
   winnerHits?: Record<string, { positive?: string[]; negative?: string[] }> | undefined;
   productActions?: Record<string, { title: string; type: string; payload?: unknown }> | undefined;
   keyDifferencesHtml?: string | undefined;
+  locale?: string | undefined;
   i18n?: ComparisonTableI18n | undefined;
   pricing?: PriceFormatConfig | undefined;
 }
@@ -352,7 +362,7 @@ export function renderComparisonTable(options: ComparisonTableOptions): HTMLElem
       const row = document.createElement('tr');
       const labelTd = document.createElement('td');
       labelTd.className = 'gengage-chat-comparison-label';
-      labelTd.textContent = formatCriteriaName(attr.label, i18n?.criteriaLabels);
+      labelTd.textContent = formatCriteriaName(attr.label, i18n?.criteriaLabels, options.locale);
       row.appendChild(labelTd);
       for (let i = 0; i < attr.values.length; i++) {
         const td = document.createElement('td');

--- a/src/chat/components/ComparisonTable.ts
+++ b/src/chat/components/ComparisonTable.ts
@@ -359,7 +359,12 @@ export function renderComparisonTable(options: ComparisonTableOptions): HTMLElem
         if (products[i]?.sku === recommended?.sku) {
           td.className = 'gengage-chat-comparison-selected gds-comparison-table-winner-cell';
         }
-        td.textContent = attr.values[i] ?? '';
+        const rawValue = attr.values[i] ?? '';
+        if (looksLikeHtml(rawValue)) {
+          td.innerHTML = sanitizeHtml(rawValue);
+        } else {
+          td.textContent = rawValue;
+        }
         row.appendChild(td);
       }
       tbody.appendChild(row);

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -4229,6 +4229,17 @@ button.gengage-chat-product-summary__cta {
   color: var(--text-secondary);
 }
 
+.gengage-chat-comparison-table td ul,
+.gengage-chat-comparison-table td ol {
+  margin: 0;
+  padding-left: 18px;
+  text-align: left;
+}
+
+.gengage-chat-comparison-table td li + li {
+  margin-top: 4px;
+}
+
 /*
  * display:grid must not be used on th — table-cell breaks and columns stack vertically.
  * Grid is only on inner wrappers; prices stay horizontally aligned across the row.

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -6946,7 +6946,7 @@ button.gengage-chat-product-details-rating {
   border-color: transparent;
   outline: none;
   box-shadow:
-    inset 0 0 0 2px color-mix(in srgb, var(--client-primary) 26%, white),
+    0 0 0 2px color-mix(in srgb, var(--client-primary) 26%, white),
     var(--shadow-1);
   filter: saturate(1.02);
 }

--- a/src/chat/components/renderUISpec.ts
+++ b/src/chat/components/renderUISpec.ts
@@ -2009,6 +2009,7 @@ function renderComparisonTableElement(element: UIElement, ctx: UISpecRenderConte
     attributes,
     highlights,
     specialCases,
+    locale: ctx.locale,
     onProductClick: ({ sku, name }) => {
       ctx.onProductClick?.({ sku, url: '', name });
     },

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -321,6 +321,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     // Create root container
     const rootEl = document.createElement('div');
     rootEl.className = 'gengage-chat-root';
+    rootEl.lang = config.locale ?? 'tr';
     this._rootEl = rootEl;
     this._shadow.appendChild(rootEl);
 

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -29,6 +29,7 @@ import {
   basketAddEvent,
 } from '../common/analytics-events.js';
 import { sanitizeHtml, isSafeUrl } from '../common/safe-html.js';
+import { resolveLocaleTag } from '../common/locale.js';
 import { debugLog } from '../common/debug.js';
 import { escapeCssIdentifier } from '../common/css-escape.js';
 import { validateImageFile } from './attachment-utils.js';
@@ -321,7 +322,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     // Create root container
     const rootEl = document.createElement('div');
     rootEl.className = 'gengage-chat-root';
-    rootEl.lang = config.locale ?? 'tr';
+    rootEl.lang = resolveLocaleTag(config.locale);
     this._rootEl = rootEl;
     this._shadow.appendChild(rootEl);
 
@@ -1832,7 +1833,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       session_id: this.config.session?.sessionId ?? '',
       correlation_id: this.config.session?.sessionId ?? '',
       type: enrichedAction.type,
-      locale: this.config.locale ?? 'tr',
+      locale: resolveLocaleTag(this.config.locale),
       meta,
       context: {
         // Spread backend context (panel, message_id, etc.) but preserve FE's
@@ -3607,6 +3608,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
    */
   private _buildRenderContext(): ChatUISpecRenderContext {
     const ctx: ChatUISpecRenderContext = {
+      locale: resolveLocaleTag(this.config.locale),
       onAction: (action) => {
         ga.trackSuggestedQuestion(action.title, action.type);
         if (action.type === 'addToCart') {

--- a/src/chat/session-persistence.ts
+++ b/src/chat/session-persistence.ts
@@ -16,6 +16,8 @@ import type { ThumbnailEntry } from './components/ThumbnailsColumn.js';
 
 export type { FavoriteData };
 
+type NavigateFn = (url: string) => void;
+
 export interface PersistSessionParams {
   userId: string;
   appId: string;
@@ -141,7 +143,14 @@ export class SessionPersistence {
    * after posting saveSessionAndOpenURL to the iframe. The clean-room runs in
    * the same window (Shadow DOM, not iframe), so it navigates directly.
    */
-  async saveAndOpenURL(url: string, persistFn: () => Promise<void>, bridge: CommunicationBridge | null): Promise<void> {
+  async saveAndOpenURL(
+    url: string,
+    persistFn: () => Promise<void>,
+    bridge: CommunicationBridge | null,
+    navigate: NavigateFn = (targetUrl) => {
+      window.location.href = targetUrl;
+    },
+  ): Promise<void> {
     try {
       await persistFn();
     } catch {
@@ -155,7 +164,7 @@ export class SessionPersistence {
     // on the gengage:navigate CustomEvent to suppress the fallback navigation.
     bridge?.send('openURLInNewTab', { url });
     if (isSafeUrl(url)) {
-      window.location.href = url;
+      navigate(url);
     }
   }
 

--- a/src/chat/types.ts
+++ b/src/chat/types.ts
@@ -385,6 +385,7 @@ export interface ProductPriceUiConfig {
 }
 
 export interface ChatUISpecRenderContext {
+  locale?: string | undefined;
   onAction: (action: ActionPayload) => void;
   onProductClick?: (params: { sku: string; url: string; name?: string }) => void;
   onAddToCart?: (params: import('../common/types.js').AddToCartParams) => void;

--- a/src/common/action-router.ts
+++ b/src/common/action-router.ts
@@ -16,6 +16,7 @@ export interface ActionRouterOptions {
   allowScriptCall?: boolean;
   unknownActionPolicy?: UnknownActionPolicy;
   logger?: Pick<Console, 'warn' | 'error' | 'debug'>;
+  defaultNavigate?: (url: string, newTab?: boolean) => void;
 }
 
 const defaultLogger: Pick<Console, 'warn' | 'error' | 'debug'> = console;
@@ -48,7 +49,7 @@ export function routeStreamAction(
         handlers.navigate({ url: action.url, ...(newTab !== undefined && { newTab }) });
         return;
       }
-      defaultNavigate(action.url, newTab);
+      (options.defaultNavigate ?? defaultNavigate)(action.url, newTab);
       return;
     }
     case 'save_session': {

--- a/src/common/locale.ts
+++ b/src/common/locale.ts
@@ -1,0 +1,4 @@
+export function resolveLocaleTag(locale: string | null | undefined): string {
+  const trimmed = locale?.trim();
+  return trimmed ? trimmed : 'tr';
+}

--- a/src/qna/index.ts
+++ b/src/qna/index.ts
@@ -69,6 +69,7 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
     this._contentEl = document.createElement('div');
     this._contentEl.className = 'gengage-qna-container';
     this._contentEl.dataset['gengagePart'] = 'qna-container';
+    this._contentEl.lang = config.locale ?? 'tr';
     this.root.appendChild(this._contentEl);
 
     const sku = config.pageContext?.sku;

--- a/src/qna/index.ts
+++ b/src/qna/index.ts
@@ -14,6 +14,7 @@ import type { ChatTransportConfig } from '../common/api-paths.js';
 import type { UISpecRenderHelpers } from '../common/renderer/index.js';
 import { mergeUISpecRegistry } from '../common/renderer/index.js';
 import { BaseWidget } from '../common/widget-base.js';
+import { resolveLocaleTag } from '../common/locale.js';
 import { dispatch } from '../common/events.js';
 import { trackConnectionWarningRequest } from '../common/connection-warning.js';
 import { getGlobalErrorMessage } from '../common/global-error-toast.js';
@@ -69,7 +70,7 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
     this._contentEl = document.createElement('div');
     this._contentEl.className = 'gengage-qna-container';
     this._contentEl.dataset['gengagePart'] = 'qna-container';
-    this._contentEl.lang = config.locale ?? 'tr';
+    this._contentEl.lang = resolveLocaleTag(config.locale);
     this.root.appendChild(this._contentEl);
 
     const sku = config.pageContext?.sku;
@@ -185,7 +186,7 @@ export class GengageQNA extends BaseWidget<QNAWidgetConfig> {
         session_id: this.config.session?.sessionId ?? '',
         correlation_id: this.config.session?.sessionId ?? '',
         sku,
-        locale: this.config.locale ?? 'tr',
+        locale: resolveLocaleTag(this.config.locale),
       };
       const pageType = this.config.pageContext?.pageType;
       if (pageType !== undefined) launcherReq.page_type = pageType;

--- a/src/simbut/index.ts
+++ b/src/simbut/index.ts
@@ -10,6 +10,7 @@
 import { BaseWidget } from '../common/widget-base.js';
 import type { PageContext } from '../common/types.js';
 import { isSafeUrl } from '../common/safe-html.js';
+import { resolveLocaleTag } from '../common/locale.js';
 import * as ga from '../common/ga-datalayer.js';
 import { SIMBUT_I18N_TR, SIMBUT_I18N_EN } from './locales.js';
 import type { GengageChat } from '../chat/index.js';
@@ -40,7 +41,6 @@ export class GengageSimBut extends BaseWidget<SimButWidgetConfig> {
   protected async onInit(config: SimButWidgetConfig): Promise<void> {
     this._label = resolveLabel(config.locale, config.i18n);
     this.root.classList.add('gengage-simbut-root');
-    this.root.lang = config.locale ?? 'tr';
 
     // Mutlak pill için konum bağlamı; static bırakılırsa top/right görselin dışına kaçabilir.
     const pos = window.getComputedStyle(this.root).position;
@@ -51,6 +51,7 @@ export class GengageSimBut extends BaseWidget<SimButWidgetConfig> {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'gengage-chat-find-similar-pill';
+    btn.lang = resolveLocaleTag(config.locale);
     btn.textContent = this._label;
     this._button = btn;
 

--- a/src/simbut/index.ts
+++ b/src/simbut/index.ts
@@ -40,6 +40,7 @@ export class GengageSimBut extends BaseWidget<SimButWidgetConfig> {
   protected async onInit(config: SimButWidgetConfig): Promise<void> {
     this._label = resolveLabel(config.locale, config.i18n);
     this.root.classList.add('gengage-simbut-root');
+    this.root.lang = config.locale ?? 'tr';
 
     // Mutlak pill için konum bağlamı; static bırakılırsa top/right görselin dışına kaçabilir.
     const pos = window.getComputedStyle(this.root).position;

--- a/src/simrel/index.ts
+++ b/src/simrel/index.ts
@@ -11,6 +11,7 @@ import type { ChatTransportConfig } from '../common/api-paths.js';
 import type { UISpecRenderHelpers } from '../common/renderer/index.js';
 import { mergeUISpecRegistry } from '../common/renderer/index.js';
 import { BaseWidget } from '../common/widget-base.js';
+import { resolveLocaleTag } from '../common/locale.js';
 import { dispatch } from '../common/events.js';
 import { trackConnectionWarningRequest } from '../common/connection-warning.js';
 import { getGlobalErrorMessage } from '../common/global-error-toast.js';
@@ -67,7 +68,7 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
     this._contentEl = document.createElement('div');
     this._contentEl.className = 'gengage-simrel-container';
     this._contentEl.dataset['gengagePart'] = 'simrel-container';
-    this._contentEl.lang = config.locale ?? 'tr';
+    this._contentEl.lang = resolveLocaleTag(config.locale);
     const gridCols = this._clampGridColumns(config.gridColumns);
     if (gridCols !== undefined) {
       this._contentEl.style.setProperty('--gengage-simrel-columns', String(gridCols));

--- a/src/simrel/index.ts
+++ b/src/simrel/index.ts
@@ -67,6 +67,7 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
     this._contentEl = document.createElement('div');
     this._contentEl.className = 'gengage-simrel-container';
     this._contentEl.dataset['gengagePart'] = 'simrel-container';
+    this._contentEl.lang = config.locale ?? 'tr';
     const gridCols = this._clampGridColumns(config.gridColumns);
     if (gridCols !== undefined) {
       this._contentEl.style.setProperty('--gengage-simrel-columns', String(gridCols));

--- a/tests/action-router.test.ts
+++ b/tests/action-router.test.ts
@@ -121,20 +121,23 @@ describe('routeStreamAction', () => {
   });
 
   it('allows default navigation to https: URLs', () => {
+    const defaultNavigate = vi.fn();
     const event: StreamEventAction = {
       type: 'action',
       action: { kind: 'navigate', url: 'https://example.com/product' },
     };
-    // This would normally navigate; in test env, window.location.href is mocked/no-op
-    expect(() => routeStreamAction(event, {})).not.toThrow();
+    expect(() => routeStreamAction(event, {}, { defaultNavigate })).not.toThrow();
+    expect(defaultNavigate).toHaveBeenCalledWith('https://example.com/product', undefined);
   });
 
   it('allows default navigation to relative URLs', () => {
+    const defaultNavigate = vi.fn();
     const event: StreamEventAction = {
       type: 'action',
       action: { kind: 'navigate', url: '/product/123' },
     };
-    expect(() => routeStreamAction(event, {})).not.toThrow();
+    expect(() => routeStreamAction(event, {}, { defaultNavigate })).not.toThrow();
+    expect(defaultNavigate).toHaveBeenCalledWith('/product/123', undefined);
   });
 
   it('treats navigate without url string as unknown action', () => {

--- a/tests/criteria-display-names.test.ts
+++ b/tests/criteria-display-names.test.ts
@@ -16,6 +16,20 @@ describe('Criteria Display Name Mapping', () => {
     expect(formatCriteriaName('usb_port_count')).toBe('Usb port count');
   });
 
+  it('uses Turkish locale-aware fallback capitalization by default', () => {
+    expect(formatCriteriaName('istanbul_ilcesi')).toBe('İstanbul ilcesi');
+    expect(formatCriteriaName('ışık_tipi')).toBe('Işık tipi');
+  });
+
+  it('uses the provided locale for fallback capitalization', () => {
+    expect(formatCriteriaName('istanbul_district', undefined, 'en-US')).toBe('Istanbul district');
+    expect(formatCriteriaName('istanbul_ilcesi', undefined, '')).toBe('İstanbul ilcesi');
+  });
+
+  it('falls back safely when the provided locale is invalid', () => {
+    expect(formatCriteriaName('istanbul_ilcesi', undefined, 'bad locale')).toBe('İstanbul ilcesi');
+  });
+
   it('passes through already-formatted labels unchanged', () => {
     expect(formatCriteriaName('Screen Size')).toBe('Screen Size');
   });

--- a/tests/locale.test.ts
+++ b/tests/locale.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLocaleTag } from '../src/common/locale.js';
+
+describe('resolveLocaleTag', () => {
+  it('falls back to Turkish for missing or blank locales', () => {
+    expect(resolveLocaleTag(undefined)).toBe('tr');
+    expect(resolveLocaleTag(null)).toBe('tr');
+    expect(resolveLocaleTag('')).toBe('tr');
+    expect(resolveLocaleTag('   ')).toBe('tr');
+  });
+
+  it('preserves a provided locale tag after trimming', () => {
+    expect(resolveLocaleTag('en-US')).toBe('en-US');
+    expect(resolveLocaleTag(' tr-TR ')).toBe('tr-TR');
+  });
+});

--- a/tests/session-persistence.test.ts
+++ b/tests/session-persistence.test.ts
@@ -288,34 +288,38 @@ describe('SessionPersistence', () => {
     it('calls persistFn and sends bridge message', async () => {
       const persistFn = vi.fn().mockResolvedValue(undefined);
       const bridge = createMockBridge();
+      const navigate = vi.fn();
 
-      await sp.saveAndOpenURL('https://example.com/product', persistFn, bridge);
+      await sp.saveAndOpenURL('https://example.com/product', persistFn, bridge, navigate);
 
       expect(persistFn).toHaveBeenCalledTimes(1);
       expect(bridge.send).toHaveBeenCalledWith('openURLInNewTab', { url: 'https://example.com/product' });
+      expect(navigate).toHaveBeenCalledWith('https://example.com/product');
     });
 
     it('navigates even when persistFn throws', async () => {
       const persistFn = vi.fn().mockRejectedValue(new Error('IDB failure'));
       const bridge = createMockBridge();
+      const navigate = vi.fn();
 
-      await sp.saveAndOpenURL('https://example.com', persistFn, bridge);
+      await sp.saveAndOpenURL('https://example.com', persistFn, bridge, navigate);
 
       expect(bridge.send).toHaveBeenCalledTimes(1);
+      expect(navigate).toHaveBeenCalledWith('https://example.com');
     });
 
     it('does not navigate for unsafe URLs (javascript:)', async () => {
       const persistFn = vi.fn().mockResolvedValue(undefined);
-      const originalHref = window.location.href;
+      const navigate = vi.fn();
 
-      await sp.saveAndOpenURL('javascript:alert(1)', persistFn, null);
+      await sp.saveAndOpenURL('javascript:alert(1)', persistFn, null, navigate);
 
-      expect(window.location.href).toBe(originalHref);
+      expect(navigate).not.toHaveBeenCalled();
     });
 
     it('works when bridge is null', async () => {
       const persistFn = vi.fn().mockResolvedValue(undefined);
-      await expect(sp.saveAndOpenURL('https://example.com', persistFn, null)).resolves.toBeUndefined();
+      await expect(sp.saveAndOpenURL('https://example.com', persistFn, null, vi.fn())).resolves.toBeUndefined();
     });
   });
 

--- a/tests/simbut-widget.test.ts
+++ b/tests/simbut-widget.test.ts
@@ -69,4 +69,25 @@ describe('GengageSimBut', () => {
 
     w.destroy();
   });
+
+  it('sets fallback lang on the owned pill without mutating the merchant mount', async () => {
+    const openWithAction = vi.fn();
+    const chat = { openWithAction } as unknown as import('../src/chat/index.js').GengageChat;
+
+    const w = new GengageSimBut();
+    await w.init({
+      accountId: 'acc',
+      middlewareUrl: 'https://example.com',
+      mountTarget: '#simbut-mount',
+      pageContext: { pageType: 'pdp', sku: 'SKU-3' },
+      locale: '',
+      chat,
+    });
+
+    const btn = mount.querySelector('.gengage-chat-find-similar-pill') as HTMLButtonElement;
+    expect(mount.lang).toBe('');
+    expect(btn.lang).toBe('tr');
+
+    w.destroy();
+  });
 });


### PR DESCRIPTION
- [Compare Table HTML gelen kısımların renderlanması düzenlendi.](https://www.notion.so/Comparison-Table-Text-Bug-33e663e588678049b50fc8abf8f44dbf?v=2bd663e5886780149624000cba6aa676&source=copy_link)
- [Comparison Mode'da seçilen ürün kartlarının borderları ve görselleri arasındaki görsel bug düzenlendi.](https://www.notion.so/Kar-la-t-rma-Modu-border-problemi-34c663e588678030a2fdd320759be916?v=2bd663e5886780149624000cba6aa676&source=copy_link)
- [AI Top Picks kartlarındaki labellardaki Türkçe büyük karakter problemleri düzenlendi.](https://www.notion.so/T-rk-e-Karakter-Problemleri-34c663e588678045a7f9dcaffd6059f0?v=2bd663e5886780149624000cba6aa676&source=copy_link)

## İncelenen Değişiklikler

| Alan | Durum | Not |
|---|---|---|
| `lang` atama (4 widget) | ✅ Doğru | `locale` BaseWidgetConfig'te olmadığı ve chat shadow DOM kullandığı için DRY ihlali kaçınılmaz |
| ComparisonTable HTML render | ✅ Güvenli | `looksLikeHtml` doğru çalışıyor (`< 10 >` gibi non-HTML ifadeleri yakalamıyor), `sanitizeHtml` her `innerHTML`'den önce çağrılıyor |
| `box-shadow` `inset` kaldırma | ✅ Doğru | Focus ring elemanın dışında görünmeli, `inset` kaldırmak standart davranışı restore ediyor |
| CSS `ul`/`ol` comparison table | ✅ Doğru | HTML içerik render'ını destekleyen gerekli stil |
| Versiyon bump `0.3.35` → `0.3.36` | ✅ Temiz | — |
