### PR TITLE
Chat scroll update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.35",
+      "version": "0.3.36",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.35",
+  "version": "0.3.36",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "test:demo-shell": "vitest run tests/demo-shell.test.ts",
     "test:ai-top-picks": "vitest run tests/ai-top-picks.test.ts",
     "test:choice-prompter": "vitest run tests/choice-prompter.test.ts",
-    "test:e2e": "playwright test --project=chromium",
+    "test:e2e": "env -u FORCE_COLOR -u NO_COLOR playwright test --project=chromium",
     "test:all": "npm run format && npm test && npm run test:e2e",
     "test:e2e:fullstack": "playwright test --project=full-stack",
     "docs:dev": "vitepress dev docs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from '@playwright/test';
 
+delete process.env.FORCE_COLOR;
+
+const webServerEnv = { ...process.env };
+delete webServerEnv.FORCE_COLOR;
+delete webServerEnv.NO_COLOR;
+
 export default defineConfig({
   globalSetup: './tests/e2e/global-setup.ts',
   testDir: './tests/e2e',
@@ -40,13 +46,15 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: 'npx vite --port 3001',
+      command: 'env -u FORCE_COLOR -u NO_COLOR npx vite --port 3001',
+      env: webServerEnv,
       port: 3001,
       reuseExistingServer: !process.env.CI,
       timeout: 90_000,
     },
     {
-      command: 'npx vite --config catalog/vite.config.ts --port 3002',
+      command: 'env -u FORCE_COLOR -u NO_COLOR npx vite --config catalog/vite.config.ts --port 3002',
+      env: webServerEnv,
       port: 3002,
       reuseExistingServer: !process.env.CI,
       timeout: 90_000,

--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -100,6 +100,11 @@ export interface ChatDrawerOptions {
 
 const DEFAULT_I18N: ChatI18n = CHAT_I18N_TR;
 const LOADING_STEP_INTERVAL_MS = 1400;
+const PRESENTATION_SCROLL_LOCK_MS = 1500;
+
+type SetPanelContentOptions = {
+  preserveAiZone?: boolean;
+};
 
 interface LoadingSequenceBinding {
   labelEl: HTMLElement;
@@ -1600,11 +1605,8 @@ export class ChatDrawer {
     options?: { resultEl?: HTMLElement; analyzingLabel?: string },
   ): void {
     if (!this._panelAiZoneEl.isConnected) return;
-    this._destroyLoadingBinding(this._panelAiZoneLoadingBinding);
-    this._panelAiZoneLoadingBinding = null;
+    this._clearPanelAiZoneState();
     if (state === 'hidden') {
-      this._panelAiZoneEl.innerHTML = '';
-      this._panelAiZoneEl.setAttribute('hidden', '');
       return;
     }
     this._panelAiZoneEl.removeAttribute('hidden');
@@ -1626,6 +1628,13 @@ export class ChatDrawer {
       this._panelAiZoneEl.innerHTML = '';
       this._panelAiZoneEl.appendChild(options.resultEl);
     }
+  }
+
+  private _clearPanelAiZoneState(): void {
+    this._destroyLoadingBinding(this._panelAiZoneLoadingBinding);
+    this._panelAiZoneLoadingBinding = null;
+    this._panelAiZoneEl.innerHTML = '';
+    this._panelAiZoneEl.setAttribute('hidden', '');
   }
 
   private _resetPanelAiZoneElement(): void {
@@ -1676,16 +1685,18 @@ export class ChatDrawer {
   }
 
   /** Replace panel content and show the panel. */
-  setPanelContent(el: HTMLElement): void {
+  setPanelContent(el: HTMLElement, options?: SetPanelContentOptions): void {
     this._destroyLoadingBinding(this._panelLoadingBinding);
     this._panelLoadingBinding = null;
-    this._destroyLoadingBinding(this._panelAiZoneLoadingBinding);
-    this._panelAiZoneLoadingBinding = null;
+    const preserveAiZone = options?.preserveAiZone === true;
+    if (!preserveAiZone) {
+      this._clearPanelAiZoneState();
+    }
     const wasVisible = this._panelVisible;
     // Targeted replace when the panel is already visible: swap only the content
-    // slot (or the skeleton), leaving topbar, AI zone, thumbnails, and floating
-    // element attached. Keeps DOM layout stable so no crossfade or reflow flicker
-    // is needed across stream updates (skeleton→content, content→content).
+    // slot (or the skeleton), leaving topbar, thumbnails, and floating element
+    // attached. The AI zone is preserved only when callers opt in for stream
+    // updates that own that zone.
     // Full rebuild is reserved for the first-show path so the slide-in width
     // transform has a clean starting state.
     if (wasVisible) {
@@ -1726,6 +1737,7 @@ export class ChatDrawer {
    */
   private _swapPanelContent(el: HTMLElement): void {
     this._panelTopBar.setActions(null);
+    // showPanelLoading() owns one skeleton wrapper, so the first match is the content slot.
     const skeletonEl = this._panelEl.querySelector<HTMLElement>('.gengage-chat-panel-skeleton');
     if (skeletonEl) {
       skeletonEl.replaceWith(el);
@@ -2440,8 +2452,8 @@ export class ChatDrawer {
     if (!target) target = firstAny;
     if (!target) return false;
     const now = Date.now();
-    this._programmaticScrollUntil = now + 1500;
-    this._scrollLockedUntil = Math.max(this._scrollLockedUntil, now + 1500);
+    this._programmaticScrollUntil = now + PRESENTATION_SCROLL_LOCK_MS;
+    this._scrollLockedUntil = Math.max(this._scrollLockedUntil, now + PRESENTATION_SCROLL_LOCK_MS);
     this._userScrolledUp = true;
     const performScroll = () => {
       this._scrollMessagesTo(Math.max(target!.offsetTop - 20, 0), behavior);

--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -216,8 +216,6 @@ export class ChatDrawer {
   private _voiceEnabled = false;
   private _voiceLang = 'tr-TR';
   private _ignoreNextDividerClick = false;
-  /** Cancels in-flight panel list scroll-to-top tween when a new one starts. */
-  private _panelListScrollAnimToken = 0;
   private readonly _cleanups: Array<() => void> = [];
   private _focusTrapHandler: ((e: KeyboardEvent) => void) | null = null;
   private _previouslyFocusedElement: HTMLElement | null = null;
@@ -1684,19 +1682,24 @@ export class ChatDrawer {
     this._destroyLoadingBinding(this._panelAiZoneLoadingBinding);
     this._panelAiZoneLoadingBinding = null;
     const wasVisible = this._panelVisible;
-    // Only apply opacity crossfade when swapping content in an already-visible panel.
-    // Applying it on first-show would hide the slide-in animation (opacity:0 masks the transform).
+    // Targeted replace when the panel is already visible: swap only the content
+    // slot (or the skeleton), leaving topbar, AI zone, thumbnails, and floating
+    // element attached. Keeps DOM layout stable so no crossfade or reflow flicker
+    // is needed across stream updates (skeleton→content, content→content).
+    // Full rebuild is reserved for the first-show path so the slide-in width
+    // transform has a clean starting state.
     if (wasVisible) {
-      this._panelEl.classList.add('gengage-chat-panel--transitioning');
+      this._swapPanelContent(el);
+    } else {
+      this._panelEl.innerHTML = '';
+      this._resetPanelAiZoneElement();
+      this._panelEl.appendChild(this._panelTopBar.getElement());
+      this._panelEl.appendChild(this._panelAiZoneEl);
+      this._panelTopBar.setActions(null);
+      this._panelEl.appendChild(el);
+      this._panelEl.appendChild(this._thumbnailsColumn.getElement());
+      this._panelEl.appendChild(this._panelFloatingEl);
     }
-    this._panelEl.innerHTML = '';
-    this._resetPanelAiZoneElement();
-    this._panelEl.appendChild(this._panelTopBar.getElement());
-    this._panelEl.appendChild(this._panelAiZoneEl);
-    this._panelTopBar.setActions(null);
-    this._panelEl.appendChild(el);
-    this._panelEl.appendChild(this._thumbnailsColumn.getElement());
-    this._panelEl.appendChild(this._panelFloatingEl);
     this._syncPanelTopBarFromContent(el);
     this._dividerEl.classList.remove('gengage-chat-panel-divider--hidden');
     this._panelVisible = true;
@@ -1707,13 +1710,41 @@ export class ChatDrawer {
     }
     this._syncDividerPreview();
     requestAnimationFrame(() => {
-      this._panelEl.classList.remove('gengage-chat-panel--transitioning');
       this._updateScrollAffordance();
       this._smoothScrollPanelListToTop();
     });
     // New content always reopens the panel — hide the reopen button
     if (this._reopenPanelBtn) this._reopenPanelBtn.style.display = 'none';
     this._emitHostShellSync();
+  }
+
+  /**
+   * Targeted content swap for an already-visible panel. Replaces the skeleton
+   * or the current content element with `el`, leaving topbar / AI zone /
+   * thumbnails column / floating element attached. Also resets topbar actions
+   * because the incoming content provides its own toolbar.
+   */
+  private _swapPanelContent(el: HTMLElement): void {
+    this._panelTopBar.setActions(null);
+    const skeletonEl = this._panelEl.querySelector<HTMLElement>('.gengage-chat-panel-skeleton');
+    if (skeletonEl) {
+      skeletonEl.replaceWith(el);
+      return;
+    }
+    const existing = this.getPanelContentElement();
+    if (existing) {
+      existing.replaceWith(el);
+      return;
+    }
+    // Panel is visible but has no content slot (edge case: prior clearPanel left
+    // only topbar + thumbnails). Insert `el` before the thumbnails column so the
+    // resulting order matches the full-build path.
+    const thumb = this._thumbnailsColumn.getElement();
+    if (thumb.parentElement === this._panelEl) {
+      this._panelEl.insertBefore(el, thumb);
+    } else {
+      this._panelEl.appendChild(el);
+    }
   }
 
   /** Append content to the panel without replacing existing content. */
@@ -2069,50 +2100,12 @@ export class ChatDrawer {
   }
 
   /**
-   * After new list/grid content is mounted, scroll the left panel toward the top smoothly.
-   * InnerHTML resets scrollTop to 0, so we nudge down first; a rAF tween (ease-out quint) replaces
-   * native smooth scroll for a softer deceleration.
+   * Reset the left panel scroll to the top after new list/grid content is mounted.
+   * innerHTML assignment already resets scrollTop to 0; this is a defensive pin in
+   * case subsequent DOM mutations (appended children, layout) shift it.
    */
   private _smoothScrollPanelListToTop(): void {
-    const panel = this._panelEl;
-    const reduceMotion =
-      typeof window !== 'undefined' && (window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches ?? false);
-
-    if (reduceMotion) {
-      panel.scrollTop = 0;
-      return;
-    }
-
-    this._panelListScrollAnimToken += 1;
-    const token = this._panelListScrollAnimToken;
-
-    requestAnimationFrame(() => {
-      if (token !== this._panelListScrollAnimToken) return;
-      const maxScroll = Math.max(0, panel.scrollHeight - panel.clientHeight);
-      if (maxScroll <= 0) return;
-
-      const startTop = Math.min(160, Math.max(48, maxScroll * 0.28));
-      panel.scrollTop = startTop;
-
-      const durationMs = Math.min(720, Math.max(380, 320 + Math.sqrt(startTop) * 28));
-      const t0 = performance.now();
-
-      const easeOutQuint = (t: number) => 1 - (1 - t) ** 5;
-
-      const step = (now: number) => {
-        if (token !== this._panelListScrollAnimToken) return;
-        const elapsed = now - t0;
-        const linear = Math.min(1, elapsed / durationMs);
-        const eased = easeOutQuint(linear);
-        panel.scrollTop = startTop * (1 - eased);
-        if (linear < 1) {
-          requestAnimationFrame(step);
-        } else {
-          panel.scrollTop = 0;
-        }
-      };
-      requestAnimationFrame(step);
-    });
+    this._panelEl.scrollTop = 0;
   }
 
   /** Update scroll affordance (bottom fade gradient) on the panel. */
@@ -2425,28 +2418,39 @@ export class ChatDrawer {
     }
   }
 
-  /**
-   * Smooth scroll transcript so the given thread’s first bubble is near the top.
-   * Used by centralized presentation scroll requests.
-   */
+  /** Scroll transcript so the thread’s first visible element sits near the top; skips
+   * empty/zero-height bubbles (silent or not-yet-streamed) so real content anchors instead. */
   scrollThreadIntoView(threadId: string, behavior: ScrollBehavior = 'smooth'): boolean {
     const matches = this.messagesEl.querySelectorAll(`[data-thread-id="${escapeCssIdentifier(threadId)}"]`);
     let target: HTMLElement | null = null;
+    let firstAny: HTMLElement | null = null;
     for (let i = 0; i < matches.length; i++) {
       const el = matches[i];
       if (!(el instanceof HTMLElement)) continue;
+      if (!firstAny) firstAny = el;
       if (el.classList.contains('gengage-chat-bubble--presentation-collapsed')) continue;
+      if (el.classList.contains('gengage-chat-bubble--hidden')) continue;
+      if (el.offsetHeight === 0) continue;
+      if (
+        el.classList.contains('gengage-chat-bubble--assistant') &&
+        (el.textContent?.trim().length ?? 0) === 0
+      ) {
+        continue;
+      }
       target = el;
       break;
     }
-    if (!target && matches.length > 0 && matches[0] instanceof HTMLElement) {
-      target = matches[0];
-    }
+    if (!target) target = firstAny;
     if (!target) return false;
-    const topInset = 20;
-    const nextTop = Math.max(target.offsetTop - topInset, 0);
-    this._programmaticScrollUntil = Date.now() + 700;
-    this._scrollMessagesTo(nextTop, behavior);
+    const now = Date.now();
+    this._programmaticScrollUntil = now + 1500;
+    this._scrollLockedUntil = Math.max(this._scrollLockedUntil, now + 1500);
+    this._userScrolledUp = true;
+    const performScroll = () => {
+      this._scrollMessagesTo(Math.max(target!.offsetTop - 20, 0), behavior);
+    };
+    performScroll();
+    requestAnimationFrame(performScroll);
     return true;
   }
 

--- a/src/chat/components/ChatDrawer.ts
+++ b/src/chat/components/ChatDrawer.ts
@@ -2431,10 +2431,7 @@ export class ChatDrawer {
       if (el.classList.contains('gengage-chat-bubble--presentation-collapsed')) continue;
       if (el.classList.contains('gengage-chat-bubble--hidden')) continue;
       if (el.offsetHeight === 0) continue;
-      if (
-        el.classList.contains('gengage-chat-bubble--assistant') &&
-        (el.textContent?.trim().length ?? 0) === 0
-      ) {
+      if (el.classList.contains('gengage-chat-bubble--assistant') && (el.textContent?.trim().length ?? 0) === 0) {
         continue;
       }
       target = el;

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -8525,16 +8525,6 @@ button.gengage-chat-product-details-rating {
 }
 
 /* ---------------------------------------------------------------------------
- * Panel content crossfade transition
- * ---------------------------------------------------------------------------*/
-@media (prefers-reduced-motion: no-preference) {
-  .gengage-chat-panel--transitioning {
-    opacity: 0;
-    transition: opacity 150ms ease;
-  }
-}
-
-/* ---------------------------------------------------------------------------
  * Cart success toast
  * ---------------------------------------------------------------------------*/
 .gengage-chat-cart-toast {

--- a/src/chat/features/beauty-consulting/consulting-grid.ts
+++ b/src/chat/features/beauty-consulting/consulting-grid.ts
@@ -46,3 +46,22 @@ export function renderConsultingGrid(
 ): void {
   renderConsultingStylePicker(wrapper, grid, detected.source!, detected.styleVariations, ctx);
 }
+
+/**
+ * Whether every variation in a consulting grid has completed (not `loading`).
+ *
+ * Backend may stream a consulting ProductGrid twice in one response: once
+ * with some variations still `loading`, then again with everything `ready`.
+ * The panel renderer uses this to skip the partial render and avoid a
+ * skeleton→partial→final flash; the skeleton stays visible until every
+ * variation is ready (or the stream ends with the partial spec as fallback).
+ */
+export function isConsultingGridReady(detected: ConsultingGridResult): boolean {
+  if (!detected.isConsulting) return true;
+  if (detected.styleVariations.length === 0) return true;
+  for (const variation of detected.styleVariations) {
+    const status = typeof variation.status === 'string' ? variation.status : 'ready';
+    if (status === 'loading') return false;
+  }
+  return true;
+}

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -42,6 +42,7 @@ import {
   flushBeautyStreamComplete,
   flushBeautyStreamError,
 } from './features/beauty-consulting/stream-handler.js';
+import { detectConsultingGrid, isConsultingGridReady } from './features/beauty-consulting/consulting-grid.js';
 import { createLauncher } from './components/Launcher.js';
 import type { LauncherElements } from './components/Launcher.js';
 import { playTtsAudio } from '../common/tts-player.js';
@@ -969,6 +970,15 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     setTimeout(() => this._flushPresentationScroll(), 40);
   }
 
+  /** Align inline UISpec render so the thread’s first visible node stays at the top. */
+  private _scrollInlineIntoView(inline: HTMLElement, threadId: string | null | undefined): void {
+    if (threadId) {
+      this._focusPresentationThread(threadId, 'auto');
+      return;
+    }
+    inline.scrollIntoView({ behavior: 'auto', block: 'start' });
+  }
+
   private _releasePresentationFocus(): void {
     this._presentation.releaseFocusedThread();
     this._drawer?.setPresentationFocus(null);
@@ -1874,6 +1884,14 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
     const beautyStreamState = createBeautyStreamState();
     /** AITopPicks / AIGroupingCards often arrive before product_list; flush when grid mounts. */
     let pendingPanelAiSpec: UISpec | null = null;
+    /**
+     * Consulting style-picker grids may stream twice: once with some variations
+     * still `loading`, then a final replace with everything `ready`. Rendering
+     * the partial produces a visible skeleton→partial→final flash, so we hold
+     * the partial here and only flush it if the stream ends without a fully
+     * ready replacement (fallback so the shopper never sees an empty panel).
+     */
+    let pendingConsultingSpec: UISpec | null = null;
 
     const syncPanelAiAnalysisZone = (): void => {
       if (!this._drawer) return;
@@ -2020,6 +2038,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           if (clearPanel) {
             this._clearAssistantPanelLikeStreamClearPanel();
             panelLoadingSeen = false;
+            pendingConsultingSpec = null;
           }
 
           const rootElement = spec.elements[spec.root];
@@ -2084,6 +2103,30 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           }
 
           const panelSpec = effectivePanelHint === 'panel' && this._panel ? this._panel.toPanelSpec(spec) : spec;
+
+          // Consulting style-picker gate: if the backend is still streaming
+          // `loading` variations, keep the panel skeleton up and buffer the
+          // partial spec. The final replace (all variations `ready`) will
+          // render cleanly as the first real content swap for this panel,
+          // which eliminates the skeleton→partial→final flash. Only the
+          // top-level (non-append) panel path is gated — similars-append and
+          // pure append paths are unaffected.
+          if (
+            effectivePanelHint === 'panel' &&
+            this._panel &&
+            !skipSidePanelForUISpec &&
+            componentType === 'ProductGrid' &&
+            rootElement
+          ) {
+            const consultingResult = detectConsultingGrid(rootElement);
+            if (consultingResult.isConsulting && !isConsultingGridReady(consultingResult)) {
+              pendingConsultingSpec = spec;
+              return;
+            }
+            if (consultingResult.isConsulting) {
+              pendingConsultingSpec = null;
+            }
+          }
 
           if (effectivePanelHint === 'panel' && this._panel && !skipSidePanelForUISpec) {
             const isFirstPanelContentInStream = !panelContentReceived;
@@ -2200,7 +2243,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
                 } else {
                   messagesContainer.appendChild(inline);
                 }
-                inline.scrollIntoView({ behavior: 'auto', block: 'end' });
+                this._scrollInlineIntoView(inline, botMsg.threadId);
                 this._drawer?.refreshPresentationCollapsed();
                 panelContentReceived = true;
               }
@@ -2257,7 +2300,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
                 inline.dataset['threadId'] = botMsg.threadId;
               }
               messagesContainer.appendChild(inline);
-              inline.scrollIntoView({ behavior: 'auto', block: 'end' });
+              this._scrollInlineIntoView(inline, botMsg.threadId);
               this._drawer?.refreshPresentationCollapsed();
               if (skipSidePanelForUISpec && componentType === 'ProductGrid') {
                 panelContentReceived = true;
@@ -2606,6 +2649,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           this._activeTypewriter = null;
           syncPanelAiAnalysisZone();
           pendingPanelAiSpec = null;
+          pendingConsultingSpec = null;
           this._bridge?.send('isResponding', false);
           this._bridge?.send('loadingMessage', { text: null });
           this._drawer?.removeTypingIndicator();
@@ -2733,6 +2777,26 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
           if (!isPreservePanel && threadId !== this._activeRequestThreadId) return;
           streamDone = true;
           syncPanelAiAnalysisZone();
+          // Consulting fallback: the backend never delivered a fully-ready
+          // style-picker replacement, so flush the last partial spec now so
+          // the shopper isn't left staring at a skeleton. Single render →
+          // still no flash.
+          if (pendingConsultingSpec && this._panel && this._drawer) {
+            const fallbackCtx = this._buildRenderContext();
+            fallbackCtx.isStreaming = false;
+            const fallbackRoot = pendingConsultingSpec.elements[pendingConsultingSpec.root];
+            const fallbackPanelSpec = this._panel.toPanelSpec(pendingConsultingSpec);
+            this._applyPanelListHeadingToContext(fallbackCtx, { kind: 'spec', spec: fallbackPanelSpec });
+            this._drawer.setPanelContent(this._renderUISpec(fallbackPanelSpec, fallbackCtx));
+            this._currentPanelSource = { kind: 'spec', spec: fallbackPanelSpec };
+            this._panel.currentType = fallbackRoot?.type ?? 'ProductGrid';
+            const backendTitle = fallbackRoot?.props?.['panelTitle'] as string | undefined;
+            this._panel.updateTopBar(this._panel.currentType, backendTitle);
+            this._panel.updateExtendedMode(this._panel.currentType);
+            this._drawer.setDividerPreviewEnabled(this._panel.currentType === 'ProductGrid');
+            panelContentReceived = true;
+          }
+          pendingConsultingSpec = null;
           // product_list never arrived but AI Top Picks / groupings were deferred — show in chat
           if (pendingPanelAiSpec) {
             const flushCtx = this._buildRenderContext();
@@ -2742,7 +2806,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
               const inline = this._renderUISpec(pendingPanelAiSpec, flushCtx);
               if (botMsg.threadId) inline.dataset['threadId'] = botMsg.threadId;
               messagesContainer.appendChild(inline);
-              inline.scrollIntoView({ behavior: 'auto', block: 'end' });
+              this._scrollInlineIntoView(inline, botMsg.threadId);
               this._drawer?.refreshPresentationCollapsed();
             }
             pendingPanelAiSpec = null;
@@ -3683,7 +3747,7 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             summaryEl.dataset['threadId'] = this._currentThreadId;
           }
           messagesContainer.appendChild(summaryEl);
-          summaryEl.scrollIntoView({ behavior: 'auto', block: 'end' });
+          this._scrollInlineIntoView(summaryEl, this._currentThreadId);
           this._drawer?.refreshPresentationCollapsed();
         }
         if (this.config.productDetailsExtended !== true) {

--- a/src/chat/index.ts
+++ b/src/chat/index.ts
@@ -5,7 +5,7 @@
  * for CSS isolation. Handles streaming NDJSON from the backend.
  */
 
-import type { ActionPayload, PageContext, StreamEvent, StreamEventAction, UISpec } from '../common/types.js';
+import type { ActionPayload, PageContext, StreamEvent, StreamEventAction, UIElement, UISpec } from '../common/types.js';
 import type { ChatTransportConfig } from '../common/api-paths.js';
 import type { ActionRouterOptions } from '../common/action-router.js';
 import type { UISpecRenderHelpers } from '../common/renderer/index.js';
@@ -77,7 +77,7 @@ import type {
 import { GengageIndexedDB } from '../common/indexed-db.js';
 import { CHAT_I18N_TR, resolveChatLocale } from './locales/index.js';
 import { ExtendedModeManager } from './extendedModeManager.js';
-import { PanelManager, determinePanelUpdateAction } from './panel-manager.js';
+import { PanelManager, determinePanelUpdateAction, type PanelUpdateAction } from './panel-manager.js';
 import { SessionPersistence } from './session-persistence.js';
 import { ChatPresentationState, getLatestUnreadAssistantThreadId } from './chat-presentation-state.js';
 import { invalidateChatScrollCache } from './utils/get-chat-scroll-element.js';
@@ -1907,6 +1907,82 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
       }
     };
 
+    const flushPendingPanelAiSpecToZone = (isStreaming: boolean): void => {
+      if (!pendingPanelAiSpec || !this._drawer) return;
+      const flushCtx = this._buildRenderContext();
+      flushCtx.isStreaming = isStreaming;
+      const aiEl = this._renderUISpec(pendingPanelAiSpec, flushCtx);
+      aiAnalysisUiReceivedForPanel = true;
+      this._drawer.setPanelAiZoneState('results', { resultEl: aiEl });
+      pendingPanelAiSpec = null;
+    };
+
+    const syncPanelAiZoneAfterPanelUpdate = (
+      componentType: string,
+      panelAction: PanelUpdateAction,
+      isStreaming: boolean,
+    ): void => {
+      if (componentType === 'ProductGrid' || componentType === 'CategoriesContainer') {
+        panelListEligibleForAiZone = !this._isMobileViewport;
+        flushPendingPanelAiSpecToZone(isStreaming);
+        syncPanelAiAnalysisZone();
+        return;
+      }
+      if (panelAction !== 'appendSimilars' && panelAction !== 'append') {
+        panelListEligibleForAiZone = false;
+        aiAnalysisUiReceivedForPanel = false;
+        pendingPanelAiSpec = null;
+        this._drawer?.setPanelAiZoneState('hidden');
+      }
+    };
+
+    const shouldPreserveAiZoneForPanelReplace = (componentType: string): boolean =>
+      (componentType === 'ProductGrid' || componentType === 'CategoriesContainer') &&
+      (panelListEligibleForAiZone || aiAnalysisUiReceivedForPanel || pendingPanelAiSpec !== null);
+
+    const replacePanelSpec = (
+      panelSpec: UISpec,
+      renderContext: ChatUISpecRenderContext,
+      componentType: string,
+    ): void => {
+      if (!this._drawer || !this._panel) return;
+      this._comparisonSelectMode = false;
+      this._comparisonSelectedSkus = [];
+      this._comparisonSelectionWarning = null;
+      this._drawer.setComparisonDockContent(null);
+      this._drawer.setPanelContent(this._renderUISpec(panelSpec, renderContext), {
+        preserveAiZone: shouldPreserveAiZoneForPanelReplace(componentType),
+      });
+      this._currentPanelSource = { kind: 'spec', spec: panelSpec };
+      this._panel.currentType = componentType;
+    };
+
+    const finalizePanelUpdate = (
+      componentType: string,
+      rootElement: UIElement | undefined,
+      panelAction: PanelUpdateAction,
+      isStreaming: boolean,
+    ): void => {
+      if (!this._panel) return;
+      this._drawer?.setDividerPreviewEnabled((this._panel.currentType ?? componentType) === 'ProductGrid');
+
+      if (componentType === 'ProductDetailsPanel' && action.type === 'launchSingleProduct') {
+        this._clearUnavailableProductContext();
+      }
+
+      if (botMsg.threadId && !this._panel.threads.includes(botMsg.threadId)) {
+        this._panel.threads.push(botMsg.threadId);
+      }
+      const titleType = this._panel.currentType ?? componentType;
+      const backendTitle = rootElement?.props?.['panelTitle'] as string | undefined;
+      this._panel.updateTopBar(titleType, backendTitle);
+      this._panel.updateExtendedMode(componentType);
+      if (this._isMobileViewport && isPdpAutoLaunch) {
+        this._drawer?.hideMobilePanel();
+      }
+      syncPanelAiZoneAfterPanelUpdate(componentType, panelAction, isStreaming);
+    };
+
     this.track(
       streamStartEvent(this.analyticsContext(), {
         endpoint: 'process_action',
@@ -2161,52 +2237,9 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
                 this._refreshComparisonUI();
               }
             } else {
-              // Reset comparison state when new panel content replaces the grid
-              this._comparisonSelectMode = false;
-              this._comparisonSelectedSkus = [];
-              this._comparisonSelectionWarning = null;
-              this._drawer?.setComparisonDockContent(null);
-              this._drawer?.setPanelContent(this._renderUISpec(panelSpec, renderContext));
-              this._currentPanelSource = { kind: 'spec', spec: panelSpec };
-              this._panel.currentType = componentType;
+              replacePanelSpec(panelSpec, renderContext, componentType);
             }
-            this._drawer?.setDividerPreviewEnabled((this._panel.currentType ?? componentType) === 'ProductGrid');
-
-            if (componentType === 'ProductDetailsPanel' && action.type === 'launchSingleProduct') {
-              this._clearUnavailableProductContext();
-            }
-
-            // Track panel thread and update topbar + extended mode
-            if (botMsg.threadId && !this._panel.threads.includes(botMsg.threadId)) {
-              this._panel.threads.push(botMsg.threadId);
-            }
-            // Use the primary panel type for title (don't let appended grids overwrite it).
-            // Backend-provided panelTitle (e.g. search results title) takes precedence.
-            const titleType = this._panel.currentType ?? componentType;
-            const backendTitle = rootElement?.props?.['panelTitle'] as string | undefined;
-            this._panel.updateTopBar(titleType, backendTitle);
-            this._panel.updateExtendedMode(componentType);
-            if (this._isMobileViewport && isPdpAutoLaunch) {
-              this._drawer?.hideMobilePanel();
-            }
-
-            // Desktop AI analysis zone: list/grid in panel → analyzing strip until Top Picks / groupings
-            if (componentType === 'ProductGrid' || componentType === 'CategoriesContainer') {
-              panelListEligibleForAiZone = !this._isMobileViewport;
-              // Top Picks / groupings may have streamed before product_list — apply now that panel + zone exist
-              if (pendingPanelAiSpec) {
-                const flushCtx = this._buildRenderContext();
-                flushCtx.isStreaming = true;
-                const aiEl = this._renderUISpec(pendingPanelAiSpec, flushCtx);
-                aiAnalysisUiReceivedForPanel = true;
-                this._drawer?.setPanelAiZoneState('results', { resultEl: aiEl });
-                pendingPanelAiSpec = null;
-              }
-            } else if (panelAction !== 'appendSimilars' && panelAction !== 'append') {
-              panelListEligibleForAiZone = false;
-              pendingPanelAiSpec = null;
-              this._drawer?.setPanelAiZoneState('hidden');
-            }
+            finalizePanelUpdate(componentType, rootElement, panelAction, true);
           }
 
           // ProductDetailsPanel goes to the panel, but also render a compact
@@ -2787,13 +2820,9 @@ export class GengageChat extends BaseWidget<ChatWidgetConfig> {
             const fallbackRoot = pendingConsultingSpec.elements[pendingConsultingSpec.root];
             const fallbackPanelSpec = this._panel.toPanelSpec(pendingConsultingSpec);
             this._applyPanelListHeadingToContext(fallbackCtx, { kind: 'spec', spec: fallbackPanelSpec });
-            this._drawer.setPanelContent(this._renderUISpec(fallbackPanelSpec, fallbackCtx));
-            this._currentPanelSource = { kind: 'spec', spec: fallbackPanelSpec };
-            this._panel.currentType = fallbackRoot?.type ?? 'ProductGrid';
-            const backendTitle = fallbackRoot?.props?.['panelTitle'] as string | undefined;
-            this._panel.updateTopBar(this._panel.currentType, backendTitle);
-            this._panel.updateExtendedMode(this._panel.currentType);
-            this._drawer.setDividerPreviewEnabled(this._panel.currentType === 'ProductGrid');
+            const fallbackType = fallbackRoot?.type ?? 'ProductGrid';
+            replacePanelSpec(fallbackPanelSpec, fallbackCtx, fallbackType);
+            finalizePanelUpdate(fallbackType, fallbackRoot, 'replace', false);
             panelContentReceived = true;
           }
           pendingConsultingSpec = null;

--- a/src/chat/session-persistence.ts
+++ b/src/chat/session-persistence.ts
@@ -10,6 +10,7 @@
 import type { GengageIndexedDB, FavoriteData } from '../common/indexed-db.js';
 import type { CommunicationBridge } from '../common/communication-bridge.js';
 import { isSafeUrl } from '../common/safe-html.js';
+import { navigateToUrl } from '../common/navigation.js';
 import type { BackendContext, UISpec } from '../common/types.js';
 import type { ChatMessage, SerializableChatMessage } from './types.js';
 import type { ThumbnailEntry } from './components/ThumbnailsColumn.js';
@@ -155,7 +156,7 @@ export class SessionPersistence {
     // on the gengage:navigate CustomEvent to suppress the fallback navigation.
     bridge?.send('openURLInNewTab', { url });
     if (isSafeUrl(url)) {
-      window.location.href = url;
+      navigateToUrl(url);
     }
   }
 

--- a/src/common/action-router.ts
+++ b/src/common/action-router.ts
@@ -2,6 +2,7 @@ import type { UnknownActionPolicy } from './config-schema.js';
 import type { ActionPayload, AddToCartParams, StreamEventAction } from './types.js';
 import { isSafeUrl } from './safe-html.js';
 import { debugLog } from './debug.js';
+import { navigateToUrl } from './navigation.js';
 
 export interface HostActionHandlers {
   openChat?: (payload?: ActionPayload | unknown) => void;
@@ -122,11 +123,7 @@ function defaultNavigate(url: string, newTab?: boolean): void {
     console.warn('[gengage] Blocked navigation to unsafe URL:', url);
     return;
   }
-  if (newTab) {
-    window.open(url, '_blank', 'noopener,noreferrer');
-    return;
-  }
-  window.location.href = url;
+  navigateToUrl(url, newTab);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/common/navigation.ts
+++ b/src/common/navigation.ts
@@ -1,0 +1,25 @@
+import { isSafeUrl } from './safe-html.js';
+
+export type NavigationRequestDetail = {
+  url: string;
+  newTab?: boolean;
+};
+
+export function navigateToUrl(url: string, newTab?: boolean): boolean {
+  if (typeof window === 'undefined') return false;
+  if (!isSafeUrl(url)) return false;
+
+  const detail: NavigationRequestDetail = newTab === undefined ? { url } : { url, newTab };
+  const event = new CustomEvent<NavigationRequestDetail>('gengage:navigate', {
+    detail,
+    cancelable: true,
+  });
+  if (!window.dispatchEvent(event)) return false;
+
+  if (newTab) {
+    window.open(url, '_blank', 'noopener,noreferrer');
+  } else {
+    window.location.href = url;
+  }
+  return true;
+}

--- a/tests/panel-patching.test.ts
+++ b/tests/panel-patching.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ChatDrawer } from '../src/chat/components/ChatDrawer.js';
 import { CHAT_I18N_EN } from '../src/chat/locales/en.js';
 
 function createDrawer() {
   const container = document.createElement('div');
+  document.body.appendChild(container);
   return new ChatDrawer(container, {
     i18n: CHAT_I18N_EN,
     onSend: vi.fn(),
@@ -12,6 +13,10 @@ function createDrawer() {
 }
 
 describe('Panel patching (Item 11)', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
   it('getPanelContentElement returns null when panel is empty', () => {
     const drawer = createDrawer();
     expect(drawer.getPanelContentElement()).toBeNull();
@@ -48,6 +53,47 @@ describe('Panel patching (Item 11)', () => {
     const el = drawer.getElement();
     expect(el.querySelector('.initial-content')).not.toBeNull();
     expect(el.querySelector('.gengage-chat-product-details-similars')).not.toBeNull();
+  });
+
+  it('setPanelContent clears the panel AI zone by default', () => {
+    const drawer = createDrawer();
+
+    const initial = document.createElement('div');
+    initial.textContent = 'Initial panel';
+    drawer.setPanelContent(initial);
+
+    const aiResult = document.createElement('div');
+    aiResult.className = 'test-ai-zone-result';
+    aiResult.textContent = 'AI picks';
+    drawer.setPanelAiZoneState('results', { resultEl: aiResult });
+    expect(drawer.getElement().querySelector('.test-ai-zone-result')).not.toBeNull();
+
+    const next = document.createElement('div');
+    next.textContent = 'Unrelated panel';
+    drawer.setPanelContent(next);
+
+    const aiZone = drawer.getElement().querySelector('.gengage-chat-panel-ai-zone');
+    expect(drawer.getElement().querySelector('.test-ai-zone-result')).toBeNull();
+    expect(aiZone?.hasAttribute('hidden')).toBe(true);
+  });
+
+  it('setPanelContent can preserve the panel AI zone for stream-owned swaps', () => {
+    const drawer = createDrawer();
+
+    const initial = document.createElement('div');
+    initial.textContent = 'Initial grid';
+    drawer.setPanelContent(initial);
+
+    const aiResult = document.createElement('div');
+    aiResult.className = 'test-ai-zone-result';
+    aiResult.textContent = 'AI picks';
+    drawer.setPanelAiZoneState('results', { resultEl: aiResult });
+
+    const next = document.createElement('div');
+    next.textContent = 'Updated grid';
+    drawer.setPanelContent(next, { preserveAiZone: true });
+
+    expect(drawer.getElement().querySelector('.test-ai-zone-result')?.textContent).toBe('AI picks');
   });
 
   it('similarsAppend flag is set in productDetailsSimilars adapter output', async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -9,3 +9,9 @@ if (typeof CSS === 'undefined' || !CSS.escape) {
     escape: (v: string) => v.replace(/([^\w-])/g, '\\$1'),
   };
 }
+
+// Unit tests assert navigation intent, not browser navigation. Prevent the
+// fallback location assignment so jsdom does not emit navigation errors.
+window.addEventListener('gengage:navigate', (event) => {
+  event.preventDefault();
+});


### PR DESCRIPTION
- [Scroll mekanizmasındaki bot mesajındaki bazı componentleri atlama durumu düzenlendi. Artık bot mesajının en üstüne smooth scroll ediyor.](https://www.notion.so/Scroll-smoothing-34c663e5886780a2a7cee0e058e6106f?v=2bd663e5886780149624000cba6aa676&source=copy_link)

## İncelenen Değişiklikler — `chat-scroll-update`

| Alan | Durum | Not |
|---|---|---|
| `_swapPanelContent()` | ✅ Doğru | Skeleton → mevcut içerik → edge-case sırası doğru; `querySelector` tek skeleton varsayımı mimariyle uyumlu |
| `scrollThreadIntoView` çift scroll | ✅ Kasıtlı | İlk çağrı anında feedback verir, rAF çağrısı layout sonrası offsetTop'u günceller; scroll çakışması riski yok |
| `_userScrolledUp = true` presentation scroll'da | ✅ Doğru | `_scrollToBottom(false)` çağrılarını 1500ms sonrasında da bastırır; scroll listener her event'te yeniden hesaplar, forced çağrılar flag'i yok sayar |
| `_smoothScrollPanelListToTop` basitleştirme | ✅ Doğru | `innerHTML` reset zaten `scrollTop = 0` yapar; tween gereksizdi, silinmesi doğru |
| `isConsultingGridReady()` | ✅ Doğru | Bilinmeyen/eksik status `'ready'` sayılır → sonsuz skeleton riski yok |
| `pendingConsultingSpec` buffer | ✅ Eksiksiz | 3 noktada temizleniyor: clearPanel, stream error, stream end |
| `_scrollInlineIntoView()` helper | ✅ Temiz | Mevcut `_focusPresentationThread` pattern'ini doğru kullanıyor, 4 tekrar satırını birleştiriyor |
| `isConsultingGridReady` — kod tekrarı | ✅ Yok | Codebase'de eşdeğer status kontrolü bulunmuyor |
| Versiyon bump `0.3.35` → `0.3.36` | ✅ Temiz | — |
