### PR TITLE
[codex] fix simrel timeout handling

### DIFF
--- a/demos/koctascomtr/index.html
+++ b/demos/koctascomtr/index.html
@@ -488,8 +488,7 @@
       const middlewareUrl = params.get('middlewareUrl') ?? 'https://chatbe-dev.gengage.ai';
 
       const brandAvatarUrl = 'https://configs.gengage.ai/koctascomtr/glov-koctascomtr-logo.svg';
-      const launcherAvatarUrl =
-        'https://configs.gengage.ai/koctascomtr/glov-koctascomtr-launcher.svg';
+      const launcherAvatarUrl = 'https://configs.gengage.ai/koctascomtr/glov-koctascomtr-launcher.svg';
 
       const skuDisplay = sku ?? '—';
       document.getElementById('dev-sku').textContent = skuDisplay;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.36",
+      "version": "0.3.37",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.36",
+  "version": "0.3.37",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/src/simrel/index.ts
+++ b/src/simrel/index.ts
@@ -34,6 +34,12 @@ import * as ga from '../common/ga-datalayer.js';
 
 import './components/simrel.css';
 
+const DEFAULT_SIMREL_REQUEST_TIMEOUT_MS = 120_000;
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
 /**
  * Similar / related products widget for product pages.
  * Fetches AI-powered product recommendations and renders them as a scrollable grid.
@@ -176,16 +182,30 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
     return this._abortController?.signal !== signal;
   }
 
+  private _resolveRequestTimeoutMs(): number {
+    const configured = this.config.requestTimeoutMs;
+    if (typeof configured !== 'number' || !Number.isFinite(configured) || configured <= 0) {
+      return DEFAULT_SIMREL_REQUEST_TIMEOUT_MS;
+    }
+    return Math.floor(configured);
+  }
+
   private async _fetchAndRender(sku: string): Promise<void> {
     this._abort();
-    this._abortController = new AbortController();
+    const controller = new AbortController();
+    this._abortController = controller;
     // Capture signal reference at invocation time to avoid race conditions:
     // if onUpdate fires between awaits, `this._abortController` gets swapped
     // but `signal` still refers to this invocation's controller.
-    const signal = this._abortController.signal;
-    // Auto-abort after 10s to prevent indefinite loading state
-    const timeoutId = setTimeout(() => this._abortController?.abort(), 10_000);
-    signal.addEventListener('abort', () => clearTimeout(timeoutId));
+    const signal = controller.signal;
+    let requestTimedOut = false;
+    // Cold similarity can legitimately run close to the backend cap; keep a client-side
+    // guard, but do not let it be shorter than the service path we are protecting.
+    const timeoutId = setTimeout(() => {
+      requestTimedOut = true;
+      controller.abort();
+    }, this._resolveRequestTimeoutMs());
+    signal.addEventListener('abort', () => clearTimeout(timeoutId), { once: true });
 
     if (!this._contentEl) return;
     this._contentEl.innerHTML = '';
@@ -335,24 +355,29 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
         }),
       );
     } catch (err) {
-      if (err instanceof DOMException && err.name === 'AbortError' && this._isSuperseded(signal)) return;
+      const abortError = isAbortError(err);
+      if (abortError && this._isSuperseded(signal)) return;
+
+      const errorCode = abortError && requestTimedOut ? 'REQUEST_TIMEOUT' : 'FETCH_ERROR';
+      const errorMessage =
+        abortError && requestTimedOut ? 'request_timeout' : err instanceof Error ? err.message : String(err);
 
       dispatch('gengage:global:error', {
         source: 'simrel',
-        code: 'FETCH_ERROR',
+        code: errorCode,
         message: getGlobalErrorMessage(this.config.locale, err),
       });
 
       this.track(
         streamErrorEvent(this.analyticsContext(), {
           request_id: requestId,
-          error_code: 'FETCH_ERROR',
-          error_message: err instanceof Error ? err.message : String(err),
+          error_code: errorCode,
+          error_message: errorMessage,
           widget: 'simrel',
         }),
       );
 
-      if (import.meta.env?.DEV) {
+      if (import.meta.env?.DEV && errorCode !== 'REQUEST_TIMEOUT') {
         console.error('[gengage:simrel] Failed to fetch similar products:', err);
       }
       // Show inline error with retry instead of hiding silently
@@ -373,6 +398,7 @@ export class GengageSimRel extends BaseWidget<SimRelWidgetConfig> {
         this._contentEl.appendChild(errorEl);
       }
     } finally {
+      clearTimeout(timeoutId);
       releaseConnectionWarning();
     }
   }

--- a/src/simrel/types.ts
+++ b/src/simrel/types.ts
@@ -64,6 +64,8 @@ export interface SimRelWidgetConfig extends BaseWidgetConfig {
    * Dar ekranlarda (≤768px) yatay kaydırmalı carousel davranışı korunur.
    */
   gridColumns?: number;
+  /** Client-side abort cap for similar-products and grouping requests. Defaults to 120 seconds. */
+  requestTimeoutMs?: number;
   domain?: string;
   /** Locale key for SDK defaults (for example 'tr', 'en'). */
   locale?: string;

--- a/tests/simrel-timeout-fallback.test.ts
+++ b/tests/simrel-timeout-fallback.test.ts
@@ -16,6 +16,7 @@ describe('GengageSimRel timeout fallback', () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
     document.body.innerHTML = '';
   });
@@ -53,6 +54,7 @@ describe('GengageSimRel timeout fallback', () => {
       sku: 'SKU-ORIGIN',
       mountTarget: '#simrel-mount',
       locale: 'tr',
+      requestTimeoutMs: 10_000,
     });
 
     await vi.advanceTimersByTimeAsync(10_100);
@@ -60,6 +62,38 @@ describe('GengageSimRel timeout fallback', () => {
 
     expect(mount.querySelector('.gengage-simrel-card')).toBeTruthy();
     expect(mount.textContent).toContain('Arcelik Klima');
+  });
+
+  it('does not log expected request timeouts as console errors', async () => {
+    const mount = document.createElement('div');
+    mount.id = 'simrel-mount';
+    document.body.appendChild(mount);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    vi.mocked(fetchSimilarProducts).mockImplementation(
+      (_request, _transport, signal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => {
+            reject(new DOMException('Timed out', 'AbortError'));
+          });
+        }),
+    );
+
+    const widget = new GengageSimRel();
+    const initPromise = widget.init({
+      accountId: 'assistant-id',
+      middlewareUrl: 'https://example.test/api/assistant-id',
+      sku: 'SKU-ORIGIN',
+      mountTarget: '#simrel-mount',
+      locale: 'tr',
+      requestTimeoutMs: 50,
+    });
+
+    await vi.advanceTimersByTimeAsync(60);
+    await initPromise;
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(mount.querySelector('.gengage-simrel-error')).toBeTruthy();
   });
 
   it('renders the flat product grid when groupings resolve without usable products', async () => {


### PR DESCRIPTION
## Summary

- raises the SimRel client-side request timeout from the hard-coded 10s cap to a configurable 120s default
- keeps the timeout scoped to the current request controller and clears the timer after completion
- classifies expected request timeout aborts as `REQUEST_TIMEOUT` without logging noisy dev-console errors

## Root Cause

The standalone SimRel widget aborted cold similarity requests after 10 seconds. The backend similarity path can legitimately take much longer on cold or uncached catalog searches, so the frontend could fail before the service returned a usable result.

## Validation

- `npm run format`
- `npm test -- tests/simrel-timeout-fallback.test.ts`