### PR TITLE
feat: render grouped watch recommendation panels

### DIFF
--- a/docs/widget-defs.md
+++ b/docs/widget-defs.md
@@ -48,7 +48,8 @@ These response types render in the Panel (desktop) or as compact mobile variants
 comparisonTable, groupList, productDetails, productDetailsSimilars, productList
 ```
 
-All other response types render exclusively in the chat pane.
+`aiProductGroupings` also renders as panel content when the payload includes
+`group_products`; otherwise it renders exclusively in the chat pane.
 
 ---
 
@@ -65,7 +66,7 @@ All other response types render exclusively in the chat pane.
 | `groupList` | Horizontal scroll (mobile only) | Tabbed category grid | Chat pane only |
 | `comparisonTable` | Compact compare (mobile only) | Full comparison table | Chat pane only |
 | `aiProductSuggestions` | AI Top Picks cards | — | Same |
-| `aiProductGroupings` | Category group cards | — | Same |
+| `aiProductGroupings` | Category group cards | Tabbed category grid when `group_products` is present | Chat pane only |
 | `aiSuggestedSearches` | Upsell suggestion cards | — | Same |
 | `getGroundingReview` | Clickable review prompt | — | Same |
 | `loading` | Loading indicator (conditional) | — | Same |
@@ -411,9 +412,18 @@ reason, expert_quality_score, review_highlight, product_item, requestDetails }`)
 
 ---
 
-### `aiProductGroupings` — Category group cards
+### `aiProductGroupings` — Category groups
 
-**Payload fields used**: `product_groupings` (array of `{ name, image, labels, sku, requestDetails }`)
+**Payload fields used**: `product_groupings` (array of `{ name, image, repr_image, labels, sku, repr_sku, requestDetails, group_products }`)
+
+When a group includes non-empty `group_products`, the adapter renders a
+panel-native `CategoriesContainer` with `panelHint: "panel"`. Group-level
+`requestDetails` is optional for this path because product cards dispatch their
+own product actions.
+
+When `group_products` is absent or empty, the adapter keeps the legacy
+`AIGroupingCards` chat-pane UI and uses `requestDetails`, `sku`, or `repr_sku`
+to build the card click action.
 
 ```
 ┌─────────────────────────────────┐

--- a/docs/widget-defs.md
+++ b/docs/widget-defs.md
@@ -421,6 +421,10 @@ panel-native `CategoriesContainer` with `panelHint: "panel"`. Group-level
 `requestDetails` is optional for this path because product cards dispatch their
 own product actions.
 
+Product-backed `aiProductGroupings` payloads should be all-or-nothing. If a
+mixed payload is received, product-backed groups take precedence and action-only
+groups are not rendered for that event.
+
 When `group_products` is absent or empty, the adapter keeps the legacy
 `AIGroupingCards` chat-pane UI and uses `requestDetails`, `sku`, or `repr_sku`
 to build the card click action.

--- a/docs/wire-protocol.md
+++ b/docs/wire-protocol.md
@@ -785,9 +785,12 @@ Only shown for the current thread and only if `!hideSuggestedActions`.
 
 When `group_products` contains products, the frontend normalizes each group to
 a panel-native `CategoriesContainer` and sets `panelHint: "panel"`. The
-group-level `requestDetails` is optional for this panel path. When
-`group_products` is absent or empty, the frontend falls back to `AIGroupingCards`
-and uses `requestDetails`, `sku`, or `repr_sku` for the card action.
+group-level `requestDetails` is optional for this panel path. Product-backed
+payloads should be all-or-nothing; in a mixed payload, product-backed groups
+take precedence and action-only groups are not rendered for that event. When
+`group_products` is absent or empty across the payload, the frontend falls back
+to `AIGroupingCards` and uses `requestDetails`, `sku`, or `repr_sku` for the
+card action.
 
 ### `aiSuggestedSearches` — Upsell search suggestions
 

--- a/docs/wire-protocol.md
+++ b/docs/wire-protocol.md
@@ -405,7 +405,7 @@ The backend streams these types. Each line is a complete JSON object followed by
 | `suggestedActions` | Action buttons/chips | ChatPane pills + input area |
 | `reviewHighlights` | Review highlights with sentiment classification | ChatPane cards |
 | `aiProductSuggestions` | AI top picks (evaluate mode) — winner/compact cards | ChatPane rich cards |
-| `aiProductGroupings` | AI product groups (explore/hybrid mode) | ChatPane cards |
+| `aiProductGroupings` | AI product groups (explore/hybrid mode) | ChatPane cards, or MainPane tabbed grid when `group_products` is present |
 | `aiSuggestedSearches` | Upsell search suggestions | ChatPane cards |
 | `getGroundingReview` | Review grounding prompt card | ChatPane clickable card |
 | `voice` | TTS audio (base64) | Audio playback |
@@ -756,6 +756,7 @@ Only shown for the current thread and only if `!hideSuggestedActions`.
       {
         "name": "Budget-Friendly Options",
         "image": "https://...",
+        "repr_image": "https://...",
         "labels": ["Under 5000 TL", "Good value"],
         "sku": "SKU123",
         "requestDetails": {
@@ -766,12 +767,27 @@ Only shown for the current thread and only if `!hideSuggestedActions`.
             "last_search_max_budget": 5000,
             "group_skus": ["SKU123", "SKU456", "SKU789"]
           }
-        }
+        },
+        "group_products": [
+          {
+            "sku": "SKU123",
+            "name": "Example Watch",
+            "images": ["https://..."],
+            "price": 12999,
+            "url": "https://..."
+          }
+        ]
       }
     ]
   }
 }
 ```
+
+When `group_products` contains products, the frontend normalizes each group to
+a panel-native `CategoriesContainer` and sets `panelHint: "panel"`. The
+group-level `requestDetails` is optional for this panel path. When
+`group_products` is absent or empty, the frontend falls back to `AIGroupingCards`
+and uses `requestDetails`, `sku`, or `repr_sku` for the card action.
 
 ### `aiSuggestedSearches` — Upsell search suggestions
 
@@ -1169,13 +1185,13 @@ The backend streams the event types listed above. The wire protocol adapter
 | `outputText` | `text_chunk` (with `final: true`) |
 | `suggestedActions` | `ui_spec` (ActionButtons) |
 | `productList` | `ui_spec` (ProductGrid) |
-| `groupList` | `ui_spec` (ProductGrid with groups) |
+| `groupList` | `ui_spec` (CategoriesContainer) with `panelHint: 'panel'` |
 | `productDetails` | `ui_spec` (ProductDetailsPanel) with `panelHint: 'panel'` |
 | `productDetailsSimilars` | `ui_spec` (SimilarProducts) — patches in-flight |
 | `comparisonTable` | `ui_spec` (ComparisonTable) with `panelHint: 'panel'` |
 | `reviewHighlights` | `ui_spec` (ReviewHighlights) |
 | `aiProductSuggestions` | `ui_spec` (AITopPicks) |
-| `aiProductGroupings` | `ui_spec` (ActionButtons) |
+| `aiProductGroupings` | `ui_spec` (CategoriesContainer) with `panelHint: 'panel'` when `group_products` is present; otherwise `ui_spec` (AIGroupingCards) |
 | `aiSuggestedSearches` | `ui_spec` (ActionButtons) |
 | `getGroundingReview` | `ui_spec` (ActionButton) |
 | `prosAndCons` | `ui_spec` (ProsAndCons) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gengage/assistant-fe",
-      "version": "0.3.37",
+      "version": "0.3.38",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@json-render/core": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gengage/assistant-fe",
-  "version": "0.3.37",
+  "version": "0.3.38",
   "description": "Source-available frontend widgets for Gengage AI Assistant — chat, Q&A, and similar-products. Backend is SaaS (gengage.ai).",
   "license": "SEE LICENSE IN LICENSE",
   "type": "module",

--- a/src/chat/catalog.ts
+++ b/src/chat/catalog.ts
@@ -267,6 +267,7 @@ export const CategoriesContainerSchema = z.object({
     .array(
       z.object({
         groupName: z.string(),
+        image: z.string().optional(),
         products: z.array(z.record(z.string(), z.unknown())).optional(),
       }),
     )

--- a/src/chat/components/CategoriesContainer.ts
+++ b/src/chat/components/CategoriesContainer.ts
@@ -17,6 +17,7 @@ import { addImageErrorHandler } from '../../common/product-utils.js';
 
 interface GroupData {
   groupName: string;
+  image?: string;
   products: NormalizedProduct[];
 }
 
@@ -71,7 +72,20 @@ export function renderCategoriesContainer(element: UIElement, context: ChatUISpe
     tab.setAttribute('aria-selected', String(i === 0));
     tab.tabIndex = i === 0 ? 0 : -1;
     if (i === 0) tab.classList.add('gengage-chat-categories-tab--active', 'is-active');
-    tab.textContent = group.groupName;
+    if (group.image && isSafeImageUrl(group.image)) {
+      const thumb = document.createElement('img');
+      thumb.className = 'gengage-chat-categories-tab-image';
+      thumb.src = group.image;
+      thumb.alt = group.groupName;
+      thumb.loading = 'lazy';
+      addImageErrorHandler(thumb);
+      tab.appendChild(thumb);
+    }
+
+    const title = document.createElement('span');
+    title.className = 'gengage-chat-categories-tab-text';
+    title.textContent = group.groupName;
+    tab.appendChild(title);
 
     tab.addEventListener('click', () => activateTab(i));
     tab.addEventListener('keydown', (e: KeyboardEvent) => {

--- a/src/chat/components/chat.css
+++ b/src/chat/components/chat.css
@@ -7998,6 +7998,9 @@ button.gengage-chat-product-details-rating {
 }
 
 .gengage-chat-categories-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
   padding: 6px 14px;
   border: 1px solid var(--border-default);
   border-radius: var(--radius-pill);
@@ -8010,6 +8013,20 @@ button.gengage-chat-product-details-rating {
     background 0.15s,
     color 0.15s,
     border-color 0.15s;
+}
+
+.gengage-chat-categories-tab-image {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  object-fit: cover;
+  flex: 0 0 auto;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-card-muted);
+}
+
+.gengage-chat-categories-tab-text {
+  min-width: 0;
 }
 
 .gengage-chat-categories-tab:hover {
@@ -8025,8 +8042,14 @@ button.gengage-chat-product-details-rating {
 
 .gengage-chat-categories-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-  gap: 8px;
+  grid-template-columns: repeat(auto-fill, minmax(176px, 1fr));
+  gap: 12px;
+}
+
+.gengage-chat-categories-grid .gengage-chat-product-card {
+  width: 100%;
+  min-width: 0;
+  max-width: none;
 }
 
 .gengage-chat-categories-filter-tags {

--- a/src/chat/panel-manager.ts
+++ b/src/chat/panel-manager.ts
@@ -146,6 +146,7 @@ export class PanelManager {
       case 'ComparisonTable':
         return i18n.panelTitleComparisonResults;
       case 'AIGroupingCards':
+      case 'CategoriesContainer':
         return i18n.panelTitleCategories;
       default:
         return '';
@@ -198,6 +199,7 @@ export class PanelManager {
     const mapping: Record<string, PanelContentType> = {
       ComparisonTable: 'comparisonTable',
       AIGroupingCards: 'groupList',
+      CategoriesContainer: 'groupList',
       ProductDetailsPanel: 'productDetails',
       ProductGrid: 'productList',
     };

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1270,6 +1270,7 @@ function adaptAiProductSuggestions(event: V1AiProductSuggestions): StreamEventUI
 
 function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec | StreamEventMetadata {
   const payloadGroupings = event.payload.product_groupings ?? [];
+  const groups: Array<{ groupName: string; image?: string; products: Record<string, unknown>[] }> = [];
   const entries: Array<Record<string, unknown>> = [];
 
   for (let i = 0; i < payloadGroupings.length; i++) {
@@ -1288,6 +1289,47 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
     }
     if (typeof grouping.image === 'string') entry['image'] = grouping.image;
     entries.push(entry);
+
+    const rawProducts = Array.isArray(grouping.group_products) ? grouping.group_products : [];
+    const normalizedProducts = rawProducts
+      .map((product) => {
+        const record = asRecord(product);
+        return record ? (productRecordToNormalized(record) as unknown as Record<string, unknown>) : null;
+      })
+      .filter(isNonNullable);
+    const groupImage =
+      firstNonEmptyString(grouping.image) ??
+      firstNonEmptyString(
+        ...normalizedProducts.map((product) => product['imageUrl']),
+      );
+    if (label && normalizedProducts.length > 0) {
+      const group = { groupName: label, products: normalizedProducts } as {
+        groupName: string;
+        image?: string;
+        products: Record<string, unknown>[];
+      };
+      if (groupImage) group.image = groupImage;
+      groups.push(group);
+    }
+  }
+
+  if (groups.length > 0) {
+    return {
+      type: 'ui_spec',
+      widget: 'chat',
+      spec: {
+        root: 'root',
+        elements: {
+          root: {
+            type: 'CategoriesContainer',
+            props: {
+              groups,
+            },
+          },
+        },
+      },
+      panelHint: 'panel',
+    };
   }
 
   if (entries.length === 0) {

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1312,6 +1312,9 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
     entries.push(entry);
   }
 
+  // Product-backed groups are panel-native content. Mixed payloads should be
+  // avoided by the backend; if they occur, product-backed groups take precedence
+  // over action-card entries for this event.
   if (groups.length > 0) {
     return {
       type: 'ui_spec',

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1296,11 +1296,7 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
     const groupImage =
       representativeImage ?? firstNonEmptyString(...normalizedProducts.map((product) => product['imageUrl']));
     if (label && normalizedProducts.length > 0) {
-      const group = { groupName: label, products: normalizedProducts } as {
-        groupName: string;
-        image?: string;
-        products: Record<string, unknown>[];
-      };
+      const group: (typeof groups)[number] = { groupName: label, products: normalizedProducts };
       if (groupImage) group.image = groupImage;
       groups.push(group);
     }

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -309,6 +309,9 @@ interface V1AiProductGrouping {
   image?: string;
   labels?: string[];
   sku?: string;
+  repr_sku?: string;
+  repr_image?: string;
+  group_products?: V1Product[];
   requestDetails?: V1RequestDetails;
   [key: string]: unknown;
 }
@@ -1277,18 +1280,11 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
     const grouping = payloadGroupings[i];
     if (!grouping) continue;
     const label = firstNonEmptyString(grouping.name) ?? '';
+    const representativeSku = firstNonEmptyString(grouping.sku, grouping.repr_sku);
+    const representativeImage = firstNonEmptyString(grouping.image, grouping.repr_image);
     const fallbackRequest: V1RequestDetails | undefined =
-      grouping.sku && grouping.sku.length > 0 ? { type: 'findSimilar', payload: { sku: grouping.sku } } : undefined;
+      representativeSku !== undefined ? { type: 'findSimilar', payload: { sku: representativeSku } } : undefined;
     const action = requestDetailsToAction(grouping.requestDetails ?? fallbackRequest, label);
-    if (!action) continue;
-
-    const entry: Record<string, unknown> = { name: label, action };
-    if (Array.isArray(grouping.labels)) {
-      const filteredLabels = grouping.labels.filter((x) => typeof x === 'string');
-      if (filteredLabels.length > 0) entry['labels'] = filteredLabels;
-    }
-    if (typeof grouping.image === 'string') entry['image'] = grouping.image;
-    entries.push(entry);
 
     const rawProducts = Array.isArray(grouping.group_products) ? grouping.group_products : [];
     const normalizedProducts = rawProducts
@@ -1298,8 +1294,7 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
       })
       .filter(isNonNullable);
     const groupImage =
-      firstNonEmptyString(grouping.image) ??
-      firstNonEmptyString(...normalizedProducts.map((product) => product['imageUrl']));
+      representativeImage ?? firstNonEmptyString(...normalizedProducts.map((product) => product['imageUrl']));
     if (label && normalizedProducts.length > 0) {
       const group = { groupName: label, products: normalizedProducts } as {
         groupName: string;
@@ -1309,6 +1304,16 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
       if (groupImage) group.image = groupImage;
       groups.push(group);
     }
+
+    if (!action) continue;
+
+    const entry: Record<string, unknown> = { name: label, action };
+    if (Array.isArray(grouping.labels)) {
+      const filteredLabels = grouping.labels.filter((x) => typeof x === 'string');
+      if (filteredLabels.length > 0) entry['labels'] = filteredLabels;
+    }
+    if (representativeImage !== undefined) entry['image'] = representativeImage;
+    entries.push(entry);
   }
 
   if (groups.length > 0) {

--- a/src/common/protocol-adapter.ts
+++ b/src/common/protocol-adapter.ts
@@ -1299,9 +1299,7 @@ function adaptAiProductGroupings(event: V1AiProductGroupings): StreamEventUISpec
       .filter(isNonNullable);
     const groupImage =
       firstNonEmptyString(grouping.image) ??
-      firstNonEmptyString(
-        ...normalizedProducts.map((product) => product['imageUrl']),
-      );
+      firstNonEmptyString(...normalizedProducts.map((product) => product['imageUrl']));
     if (label && normalizedProducts.length > 0) {
       const group = { groupName: label, products: normalizedProducts } as {
         groupName: string;

--- a/tests/panel-manager.test.ts
+++ b/tests/panel-manager.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { PanelManager } from '../src/chat/panel-manager.js';
+import { ExtendedModeManager } from '../src/chat/extendedModeManager.js';
 import { CHAT_I18N_TR } from '../src/chat/locales/index.js';
 
-function createPanelManager(): PanelManager {
+function createPanelManager(overrides: Partial<ConstructorParameters<typeof PanelManager>[0]> = {}): PanelManager {
   return new PanelManager({
     drawer: () => null,
     shadow: () => null,
@@ -11,6 +12,7 @@ function createPanelManager(): PanelManager {
     extendedModeManager: () => null,
     i18n: () => CHAT_I18N_TR,
     rollbackToThread: () => {},
+    ...overrides,
   });
 }
 
@@ -30,5 +32,19 @@ describe('PanelManager', () => {
     panel.lastActionType = 'findSimilar';
 
     expect(panel.titleForComponent('ProductGrid')).toBe(CHAT_I18N_TR.panelTitleSimilarProducts);
+  });
+
+  it('treats CategoriesContainer as category panel content', () => {
+    const changes: boolean[] = [];
+    const extended = new ExtendedModeManager({ onChange: (extendedState) => changes.push(extendedState) });
+    const panel = createPanelManager({ extendedModeManager: () => extended });
+
+    expect(panel.titleForComponent('CategoriesContainer')).toBe(CHAT_I18N_TR.panelTitleCategories);
+
+    extended.unlock();
+    extended.setChatShown(true);
+    panel.updateExtendedMode('CategoriesContainer');
+
+    expect(changes).toEqual([true]);
   });
 });

--- a/tests/protocol-adapter.test.ts
+++ b/tests/protocol-adapter.test.ts
@@ -499,6 +499,46 @@ describe('adaptBackendEvent', () => {
     expect(entries![0]!['action']).toBeDefined();
   });
 
+  it('adapts aiProductGroupings with group_products to CategoriesContainer without group action', () => {
+    const groupings = adaptBackendEvent({
+      type: 'aiProductGroupings',
+      payload: {
+        product_groupings: [
+          {
+            name: 'Dress watches',
+            repr_image: 'https://example.com/group.jpg',
+            group_products: [
+              {
+                sku: 'WATCH-1',
+                name: 'Classic Watch',
+                images: ['https://example.com/watch.jpg'],
+                price: 1250,
+                url: 'https://example.com/watch-1',
+              },
+            ],
+          },
+        ],
+      },
+    }) as {
+      type: string;
+      panelHint?: string;
+      spec?: { elements: Record<string, { type: string; props?: Record<string, unknown> }> };
+    };
+
+    expect(groupings.type).toBe('ui_spec');
+    expect(groupings.panelHint).toBe('panel');
+    expect(groupings.spec?.elements['root']?.type).toBe('CategoriesContainer');
+
+    const groups = groupings.spec?.elements['root']?.props?.['groups'] as
+      | Array<{ groupName: string; image?: string; products: Array<{ sku?: string; imageUrl?: string }> }>
+      | undefined;
+    expect(groups).toHaveLength(1);
+    expect(groups![0]!.groupName).toBe('Dress watches');
+    expect(groups![0]!.image).toBe('https://example.com/group.jpg');
+    expect(groups![0]!.products[0]?.sku).toBe('WATCH-1');
+    expect(groups![0]!.products[0]?.imageUrl).toBe('https://example.com/watch.jpg');
+  });
+
   it('adapts aiSuggestedSearches to AISuggestedSearchCards ui_spec', () => {
     const searches = adaptBackendEvent({
       type: 'aiSuggestedSearches',

--- a/tests/protocol-adapter.test.ts
+++ b/tests/protocol-adapter.test.ts
@@ -539,6 +539,47 @@ describe('adaptBackendEvent', () => {
     expect(groups![0]!.products[0]?.imageUrl).toBe('https://example.com/watch.jpg');
   });
 
+  it('prefers product-backed grouped panel content for mixed aiProductGroupings payloads', () => {
+    const groupings = adaptBackendEvent({
+      type: 'aiProductGroupings',
+      payload: {
+        product_groupings: [
+          {
+            name: 'Product-backed group',
+            group_products: [
+              {
+                sku: 'WATCH-1',
+                name: 'Classic Watch',
+                images: ['https://example.com/watch.jpg'],
+                price: 1250,
+                url: 'https://example.com/watch-1',
+              },
+            ],
+          },
+          {
+            name: 'Action-only group',
+            requestDetails: { type: 'findSimilar', payload: { sku: 'WATCH-2' } },
+          },
+        ],
+      },
+    }) as {
+      type: string;
+      panelHint?: string;
+      spec?: { elements: Record<string, { type: string; props?: Record<string, unknown> }> };
+    };
+
+    expect(groupings.type).toBe('ui_spec');
+    expect(groupings.panelHint).toBe('panel');
+    expect(groupings.spec?.elements['root']?.type).toBe('CategoriesContainer');
+
+    const groups = groupings.spec?.elements['root']?.props?.['groups'] as
+      | Array<{ groupName: string; products: Array<{ sku?: string }> }>
+      | undefined;
+    expect(groups).toHaveLength(1);
+    expect(groups![0]!.groupName).toBe('Product-backed group');
+    expect(groups![0]!.products[0]?.sku).toBe('WATCH-1');
+  });
+
   it('adapts aiSuggestedSearches to AISuggestedSearchCards ui_spec', () => {
     const searches = adaptBackendEvent({
       type: 'aiSuggestedSearches',


### PR DESCRIPTION
## Summary
This PR updates the grouped recommendation panel rendering so watch-expert results coming from `aiProductGroupings` open as a real desktop panel, feel visual, and use product-card sizing closer to the standard shopping grid.

This is the frontend pair for the backend watch-grouping cleanup in `micro-abilities`.

## What Changed

### 1. Treat grouped watch recommendations as panel-native content
- `src/common/protocol-adapter.ts`
- When `aiProductGroupings` includes real `group_products`, the adapter now emits a `CategoriesContainer` with `panelHint: 'panel'` instead of leaving the result as an analysis-only grouping card.
- This is what allows the grouped watch experience to open properly in desktop panel view.

### 2. Add a representative image per group
- `src/chat/catalog.ts`
- `src/chat/components/CategoriesContainer.ts`
- Group selectors now support an optional `image`, and the tab renderer shows a small thumbnail when one is available.
- This keeps the group selector visual instead of falling back to bare text tabs.

### 3. Make grouped rows use healthier product-card sizing
- `src/chat/components/chat.css`
- The grouped grid now uses a wider `minmax(176px, 1fr)` layout and removes the overly-tight card width constraints.
- This aligns grouped watch rows more closely with the standard product-list feel and avoids cramming too many watches into one row.

## Why
The previous grouped-result contract was structurally valid, but on desktop it could still behave like an auxiliary analysis view rather than a proper panel result. That made the watch-grouping transition feel inconsistent even when the backend payload was correct.

This PR makes grouped watch recommendations behave like first-class product-panel content.

## Verification
- `npm run build`

## Companion Backend PR
- `micro-abilities`: shared watch grouping + panel-state persistence PR will be linked separately.
